### PR TITLE
CAR-27 Fix Token Authentication To Be In line with FASTAPI Standards

### DIFF
--- a/backend/app/api/dependencies/auth.py
+++ b/backend/app/api/dependencies/auth.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Optional
 
 import bcrypt
-from fastapi import Cookie, Depends, HTTPException, status
+from fastapi import Depends, HTTPException, status
 from fastapi.security import OAuth2PasswordBearer
 from jose import JWTError, jwt
 from sqlalchemy.orm import Session
@@ -15,7 +15,10 @@ from app.db.session import get_db
 ALGORITHM = settings.HASH_ALGORITHM
 
 
+# OAuth2 scheme for Bearer token extraction (FastAPI standard)
 oauth2_scheme = OAuth2PasswordBearer(tokenUrl=f"{settings.API_STR}/auth/token")
+# auto_error=False for optional endpoints that can work without auth
+oauth2_scheme_optional = OAuth2PasswordBearer(tokenUrl=f"{settings.API_STR}/auth/token", auto_error=False)
 
 # --- Password Utilities ---
 
@@ -57,22 +60,21 @@ def create_access_token(data: dict[str, Any], expires_delta: Optional[timedelta]
 
 
 async def get_current_user(
-    access_token: Optional[str] = Cookie(None),  # Read "access_token" cookie
+    token: str = Depends(oauth2_scheme),  # Bearer token from Authorization header (FastAPI standard)
     db: Session = Depends(get_db),
 ) -> DBUser:
     """
-    Decodes JWT token from cookie, validates credentials, and returns the user.
+    Decodes JWT Bearer token from Authorization header, validates credentials, and returns the user.
+    Uses standard OAuth2 Bearer token authentication.
     """
     credentials_exception = HTTPException(
         status_code=status.HTTP_401_UNAUTHORIZED,
         detail="Could not validate credentials",
         headers={"WWW-Authenticate": "Bearer"},
     )
-    if access_token is None:
-        raise credentials_exception
 
     try:
-        payload = jwt.decode(access_token, settings.SECRET_KEY, algorithms=[settings.HASH_ALGORITHM])
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.HASH_ALGORITHM])
         username: Optional[str] = payload.get("sub")
         if username is None:
             raise credentials_exception
@@ -91,18 +93,19 @@ async def get_current_user(
 
 
 async def get_optional_current_user(
-    access_token: Optional[str] = Cookie(None),  # Read "access_token" cookie
+    token: Optional[str] = Depends(oauth2_scheme_optional),
     db: Session = Depends(get_db),
 ) -> Optional[DBUser]:
     """
-    Decodes JWT token from cookie and returns the user, or None if not authenticated.
+    Decodes JWT Bearer token and returns the user, or None if not authenticated.
     This is for endpoints that can work with or without authentication.
+    Uses standard OAuth2 Bearer token authentication.
     """
-    if access_token is None:
+    if token is None:
         return None
 
     try:
-        payload = jwt.decode(access_token, settings.SECRET_KEY, algorithms=[settings.HASH_ALGORITHM])
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.HASH_ALGORITHM])
         username: Optional[str] = payload.get("sub")
         if username is None:
             return None
@@ -118,17 +121,18 @@ async def get_optional_current_user(
 
 
 async def get_current_active_user_optional(
-    access_token: Optional[str] = Cookie(None),  # Read "access_token" cookie
+    token: Optional[str] = Depends(oauth2_scheme_optional),
     db: Session = Depends(get_db),
 ) -> Optional[DBUser]:
     """
-    Optionally returns the current active user if a valid token cookie is present.
+    Optionally returns the current active user if a valid Bearer token is present.
     Returns None if no token, token is invalid/expired, user not found, or user is inactive.
+    Uses standard OAuth2 Bearer token authentication.
     """
-    if access_token is None:
+    if token is None:
         return None
     try:
-        payload = jwt.decode(access_token, settings.SECRET_KEY, algorithms=[settings.HASH_ALGORITHM])
+        payload = jwt.decode(token, settings.SECRET_KEY, algorithms=[settings.HASH_ALGORITHM])
         username: Optional[str] = payload.get("sub")
         if username is None:
             return None  # Invalid token payload

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -57,7 +57,7 @@ async def login_for_access_token(
     return {
         "access_token": access_token,
         "token_type": "bearer",
-        "user": user,
+        "user": UserRead.model_validate(user),
     }
 
 

--- a/backend/app/api/endpoints/auth.py
+++ b/backend/app/api/endpoints/auth.py
@@ -8,7 +8,7 @@ while maintaining authentication-specific functionality.
 import logging
 from datetime import timedelta
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Query, Response
+from fastapi import APIRouter, Body, Depends, HTTPException, Query
 from fastapi.responses import RedirectResponse
 from fastapi.security import OAuth2PasswordRequestForm
 from jose import JWTError, jwt
@@ -31,16 +31,16 @@ from app.db.session import get_db
 router = APIRouter()
 
 
-@router.post("/token", response_model=UserRead)
+@router.post("/token")
 async def login_for_access_token(
-    response: Response,
     form_data: OAuth2PasswordRequestForm = Depends(),
     db: Session = Depends(get_db),
     logger: logging.Logger = Depends(get_logger),
-) -> DBUser:
+) -> dict[str, str | UserRead]:
     """
-    Authenticate user, set JWT token in an HTTP-only cookie, and return user details.
+    Authenticate user and return access token and user details.
     Takes form data: username and password.
+    Returns Bearer token in response body for standard OAuth2 flow.
     """
     user = db.query(DBUser).filter(DBUser.username == form_data.username).first()
     if not user or not verify_password(form_data.password, user.hashed_password):
@@ -53,18 +53,12 @@ async def login_for_access_token(
     access_token_data = {"sub": user.username}
     access_token = create_access_token(data=access_token_data)
 
-    response.set_cookie(
-        key="access_token",
-        value=access_token,
-        httponly=True,  # Crucial for security
-        max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,  # Cookie expiry in seconds
-        path="/",  # Cookie available for all paths
-        samesite="lax",  # Recommended for CSRF protection balance
-        secure=settings.secure_cookies,  # Use secure flag in production (HTTPS only)
-    )
-
     logger.info(f"User logged in successfully: {user.username}")
-    return user  # Return user information
+    return {
+        "access_token": access_token,
+        "token_type": "bearer",
+        "user": user,
+    }
 
 
 @router.post("/verify-email")
@@ -227,17 +221,11 @@ async def reset_password_confirm(
 
 @router.post("/logout")
 async def logout(
-    response: Response,
     logger: logging.Logger = Depends(get_logger),
 ) -> dict[str, str]:
-    """Logout user by clearing the access token cookie."""
-    response.delete_cookie(
-        key="access_token",
-        path="/",
-        httponly=True,
-        samesite="lax",
-        secure=settings.secure_cookies,  # Use secure flag in production (HTTPS only)
-    )
-
+    """
+    Logout endpoint for client-side token removal.
+    Note: With Bearer tokens, the client is responsible for removing the token from storage.
+    """
     logger.info("User logged out successfully")
     return {"message": "Logged out successfully"}

--- a/backend/app/api/endpoints/users.py
+++ b/backend/app/api/endpoints/users.py
@@ -31,7 +31,6 @@ from app.api.services.user_service import UserService
 from app.api.utils.base_endpoint_router import BaseEndpointRouter
 from app.api.utils.endpoint_decorators import crud_responses, validate_pagination_params
 from app.api.utils.response_patterns import ResponsePatterns
-from app.core.config import settings
 from app.core.logging import get_logger
 from app.db.session import get_db
 
@@ -178,22 +177,15 @@ async def update_user(
         logger.info(f"User {user_id} updated successfully by user {current_user.id}.")
 
         if username_changed:
-            logger.info(f"Username for user {user_id} changed to '{db_user.username}'. " f"Issuing new access token.")
-            # Create a new access token with the new username
+            logger.info(
+                f"Username for user {user_id} changed to '{db_user.username}'. "
+                f"Client should re-authenticate to get new token."
+            )
+            # Note: With Bearer tokens, client should re-login to get a new token with updated username
+            # Return new token in response header for convenience
             new_access_token_data = {"sub": db_user.username}
             new_access_token = create_access_token(data=new_access_token_data)
-
-            # Set the new token in an HTTP-only cookie
-            response.set_cookie(
-                key="access_token",
-                value=new_access_token,
-                httponly=True,
-                max_age=settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60,
-                path="/",
-                samesite="lax",
-                # TODO: Change to True in production if served over HTTPS
-                secure=settings.secure_cookies,  # Use secure flag in production (HTTPS only)
-            )
+            response.headers["X-New-Access-Token"] = new_access_token
 
     except IntegrityError as e:
         db.rollback()

--- a/backend/tests/api/endpoints/test_auth.py
+++ b/backend/tests/api/endpoints/test_auth.py
@@ -32,7 +32,7 @@ def create_test_user_direct_db(db: Session, username: str, email: str, password:
 
 
 def test_login_for_access_token_success(client: TestClient) -> None:
-    username = get_unique_username("auth_test_user_cookie")  # Ensure unique username for test
+    username = get_unique_username("auth_test_user")  # Ensure unique username for test
     password = "auth_test_password"
     email = f"{username}@example.com"
 
@@ -42,49 +42,47 @@ def test_login_for_access_token_success(client: TestClient) -> None:
     assert create_user_response.status_code == 200, f"Failed to create user for auth test: {create_user_response.text}"
 
     login_data = {"username": username, "password": password}
-    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)  # Changed
+    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert response.status_code == 200, response.text
 
-    # 1. Check for the cookie
-    assert "access_token" in response.cookies
-    access_token_cookie_value = response.cookies.get("access_token")
-    assert access_token_cookie_value is not None
-
-    # 2. Check cookie attributes by parsing the Set-Cookie header
-    # Note: httpx.Cookies (used by TestClient) doesn't directly expose all attributes like HttpOnly easily.
-    # Parsing the header is a reliable way.
-    set_cookie_header = response.headers.get("set-cookie")
-    assert set_cookie_header is not None
-    assert "access_token=" in set_cookie_header
-    assert "HttpOnly" in set_cookie_header
-    assert "Path=/" in set_cookie_header
-    assert f"Max-Age={settings.ACCESS_TOKEN_EXPIRE_MINUTES * 60}" in set_cookie_header
-    assert "SameSite=lax" in set_cookie_header  # Or your configured samesite policy
-    # 'secure' attribute is not set in your current /token endpoint logic for non-HTTPS dev
-    assert "Secure" not in set_cookie_header
-
-    # 3. Check the response body for user details (UserRead schema)
+    # Check the response body for Bearer token and user details (OAuth2 standard)
     response_data = response.json()
-    assert response_data["username"] == username
-    assert response_data["email"] == email
-    assert "id" in response_data
-    assert isinstance(response_data["id"], int)  # or str, depending on your UserRead schema for id
-    assert response_data["disabled"] is False
-    assert "hashed_password" not in response_data  # Ensure password is not returned
-    assert "access_token" not in response_data  # Ensure token is not in body
-    assert "token_type" not in response_data  # Ensure token_type is not in body
+
+    # 1. Check for Bearer token in response body
+    assert "access_token" in response_data
+    assert "token_type" in response_data
+    assert response_data["token_type"] == "bearer"
+    access_token = response_data["access_token"]
+    assert access_token is not None
+    assert len(access_token) > 0
+
+    # 2. Check for user details in response body
+    assert "user" in response_data
+    user_data_response = response_data["user"]
+    assert user_data_response["username"] == username
+    assert user_data_response["email"] == email
+    assert "id" in user_data_response
+    assert isinstance(user_data_response["id"], int)
+    assert user_data_response["disabled"] is False
+    assert "hashed_password" not in user_data_response  # Ensure password is not returned
+
+    # 3. Ensure no cookie is set (Bearer token approach)
+    assert "access_token" not in response.cookies
 
 
 def test_login_for_access_token_incorrect_username(client: TestClient) -> None:
-    login_data = {"username": "wronguser_cookie", "password": "password123"}
-    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)  # Changed
+    login_data = {"username": "wronguser", "password": "password123"}
+    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert response.status_code == 401
     assert response.json()["message"] == "Incorrect username or password"
-    assert "access_token" not in response.cookies  # Check no cookie is set
+    # Check no token is returned in response body
+    response_data = response.json()
+    assert "access_token" not in response_data
+    assert "access_token" not in response.cookies
 
 
 def test_login_for_access_token_incorrect_password(client: TestClient, db_session: Session) -> None:
-    username = get_unique_username("auth_test_user_wrong_pass_cookie")  # Ensure unique username
+    username = get_unique_username("auth_test_user_wrong_pass")  # Ensure unique username
     password = "correct_password"
     email = f"{username}@example.com"
 
@@ -93,14 +91,17 @@ def test_login_for_access_token_incorrect_password(client: TestClient, db_sessio
     assert create_response.status_code == 200, f"User creation failed: {create_response.text}"
 
     login_data = {"username": username, "password": "wrong_password"}
-    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)  # Changed
+    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert response.status_code == 401
     assert response.json()["message"] == "Incorrect username or password"
-    assert "access_token" not in response.cookies  # Check no cookie is set
+    # Check no token is returned in response body
+    response_data = response.json()
+    assert "access_token" not in response_data
+    assert "access_token" not in response.cookies
 
 
 def test_login_for_access_token_disabled_user(client: TestClient, db_session: Session) -> None:
-    username = get_unique_username("disabled_user_cookie")  # Ensure unique username
+    username = get_unique_username("disabled_user")  # Ensure unique username
     password = "password123"
     email = f"{username}@example.com"
 
@@ -109,33 +110,33 @@ def test_login_for_access_token_disabled_user(client: TestClient, db_session: Se
     assert create_response.status_code == 200, f"User creation failed: {create_response.text}"
     user_id = create_response.json()["id"]
 
-    # Log in as the user. The cookie will be set in the client for subsequent requests.
+    # Log in as the user to get Bearer token
     login_data_for_session = {"username": username, "password": password}
-    token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data_for_session)  # Changed
-    assert token_response.status_code == 200, f"Login to get session cookie failed: {token_response.text}"
-    assert "access_token" in token_response.cookies  # Verify cookie was set
+    token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data_for_session)
+    assert token_response.status_code == 200, f"Login to get token failed: {token_response.text}"
+    token_data = token_response.json()
+    assert "access_token" in token_data
+    access_token = token_data["access_token"]
 
-    # Disable the user via API. The client will automatically send the cookie.
-    # This assumes the PUT /users/{user_id} endpoint is protected by a dependency
-    # (e.g., get_current_user) that now reads the authentication token from the cookie.
+    # Disable the user via API using Bearer token in Authorization header
     update_payload = {
         "disabled": True,
         "current_password": password,
-    }  # Add current_password
-    # No explicit headers needed if the dependency reads from cookie
-    update_response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload)
+    }
+    headers = {"Authorization": f"Bearer {access_token}"}
+    update_response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload, headers=headers)
     assert update_response.status_code == 200, f"Failed to disable user: {update_response.text}"
     assert update_response.json()["disabled"] is True
 
-    # Clear cookies from the client to ensure the next login attempt is fresh
-    client.cookies.clear()
-
     # Attempt to login as the now disabled user
     login_data = {"username": username, "password": password}
-    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)  # Changed
+    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert response.status_code == 400, response.text
     assert response.json()["message"] == "Inactive user"
-    assert "access_token" not in response.cookies  # Ensure no new cookie is set
+    # Check no token is returned in response body
+    response_data = response.json()
+    assert "access_token" not in response_data
+    assert "access_token" not in response.cookies
 
 
 # --- Email Verification Tests ---
@@ -401,18 +402,16 @@ def test_logout_success(client: TestClient, db_session: Session) -> None:
     login_data = {"username": username, "password": password}
     login_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert login_response.status_code == 200
-    assert "access_token" in login_response.cookies
+    login_data_response = login_response.json()
+    assert "access_token" in login_data_response
 
-    # Logout
+    # Logout (with Bearer tokens, logout is client-side, but endpoint confirms)
     logout_response = client.post(f"{settings.API_STR}/auth/logout")
     assert logout_response.status_code == 200
     assert logout_response.json()["message"] == "Logged out successfully"
 
-    # Verify cookie is cleared by checking Set-Cookie header
-    set_cookie_header = logout_response.headers.get("set-cookie", "")
-    assert "access_token=" in set_cookie_header
-    # Cookie should be set with Max-Age=0 or expires in the past to delete it
-    # The exact format may vary, but it should effectively clear the cookie
+    # With Bearer tokens, the client is responsible for removing the token
+    # The endpoint just confirms logout was successful
 
 
 def test_logout_without_login(client: TestClient, db_session: Session) -> None:

--- a/backend/tests/api/endpoints/test_build_list_parts.py
+++ b/backend/tests/api/endpoints/test_build_list_parts.py
@@ -16,13 +16,19 @@ def get_unique_name(base_name: str) -> str:
     return f"{base_name}_{worker_id}_{pid}"
 
 
+def get_auth_headers(token: str) -> dict[str, str]:
+    """Get Authorization headers with Bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
 class TestBuildListParts:
     """Test cases for build list parts endpoints."""
 
     def test_add_part_to_build_list_success(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test successfully adding a part to a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -30,7 +36,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         if response.status_code != 200:
             print(f"Car creation failed: {response.status_code} - {response.json()}")
         assert response.status_code == 200
@@ -42,7 +48,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -53,7 +59,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -64,6 +70,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -88,8 +95,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a part to a non-existent build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a global part
         part_data = {
@@ -98,7 +106,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -109,13 +117,15 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/99999/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 404
 
     def test_add_part_to_build_list_part_not_found(self, client: TestClient, test_user: User) -> None:
         """Test adding a non-existent part to a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -123,7 +133,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -133,7 +143,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -144,6 +154,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/99999",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 404
 
@@ -151,8 +162,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a part to a build list without providing quantity."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -160,7 +172,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -170,7 +182,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -181,7 +193,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -192,6 +204,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -199,8 +212,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a part to a build list with invalid quantity."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -208,7 +222,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -218,7 +232,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -229,7 +243,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -240,6 +254,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -247,8 +262,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a duplicate part to a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -256,7 +272,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -266,7 +282,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -277,7 +293,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -288,6 +304,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -295,13 +312,15 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 409
 
     def test_get_build_list_parts_success(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test getting parts from a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -309,7 +328,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -319,7 +338,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -330,7 +349,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -342,11 +361,12 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
         # Get parts from build list
-        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}")
+        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}", headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -359,11 +379,12 @@ class TestBuildListParts:
 
     def test_get_build_list_parts_not_found(self, client: TestClient, test_user: User) -> None:
         """Test getting parts from a non-existent build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Try to get parts from non-existent build list
-        response = client.get(f"{settings.API_STR}/build-list-parts/99999")
+        response = client.get(f"{settings.API_STR}/build-list-parts/99999", headers=headers)
         assert response.status_code == 404
 
     def test_get_build_list_parts_unauthorized(self, client: TestClient) -> None:
@@ -374,8 +395,9 @@ class TestBuildListParts:
 
     def test_update_build_list_part_success(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test updating a build list part."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -383,7 +405,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -393,7 +415,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -404,7 +426,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -416,6 +438,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
         build_list_part = response.json()
@@ -428,6 +451,7 @@ class TestBuildListParts:
         response = client.put(
             f"{settings.API_STR}/build-list-parts/{build_list_part['id']}",
             json=update_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -438,15 +462,16 @@ class TestBuildListParts:
 
     def test_update_build_list_part_not_found(self, client: TestClient, test_user: User) -> None:
         """Test updating a build list part that doesn't exist."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Try to update a build list part that doesn't exist
         update_data = {
             "quantity": 3,
             "notes": "Updated notes",
         }
-        response = client.put(f"{settings.API_STR}/build-list-parts/99999", json=update_data)
+        response = client.put(f"{settings.API_STR}/build-list-parts/99999", json=update_data, headers=headers)
         assert response.status_code == 404
 
     def test_update_build_list_part_unauthorized(self, client: TestClient) -> None:
@@ -463,8 +488,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test updating a build list part with invalid quantity."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -472,7 +498,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -482,7 +508,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -493,7 +519,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -506,6 +532,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
         build_list_part = response.json()
@@ -518,6 +545,7 @@ class TestBuildListParts:
         response = client.put(
             f"{settings.API_STR}/build-list-parts/{build_list_part['id']}",
             json=update_data,
+            headers=headers,
         )
         assert response.status_code == 422
 
@@ -525,8 +553,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test removing a part from a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -534,7 +563,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -544,7 +573,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -555,7 +584,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -567,27 +596,29 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
         build_list_part = response.json()
 
         # Remove the part
-        response = client.delete(f"{settings.API_STR}/build-list-parts/{build_list_part['id']}")
+        response = client.delete(f"{settings.API_STR}/build-list-parts/{build_list_part['id']}", headers=headers)
         assert response.status_code == 200
 
         # Verify the part was removed
-        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}")
+        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}", headers=headers)
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 0
 
     def test_remove_part_from_build_list_not_found(self, client: TestClient, test_user: User) -> None:
         """Test removing a build list part that doesn't exist."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Try to remove a build list part that doesn't exist
-        response = client.delete(f"{settings.API_STR}/build-list-parts/99999")
+        response = client.delete(f"{settings.API_STR}/build-list-parts/99999", headers=headers)
         assert response.status_code == 404
 
     def test_remove_part_from_build_list_unauthorized(self, client: TestClient) -> None:
@@ -600,8 +631,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a part to a build list with extra fields in the request."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -609,7 +641,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -619,7 +651,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -630,7 +662,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -643,6 +675,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -655,17 +688,16 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a part to a build list with malformed JSON."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("test_build_list"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -676,15 +708,17 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
         # Try to add part with malformed JSON
+        auth_headers = headers.copy()
+        auth_headers["Content-Type"] = "application/json"
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             content="invalid json",
-            headers={"Content-Type": "application/json"},
+            headers=auth_headers,
         )
         assert response.status_code == 422
 
@@ -692,8 +726,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test adding a part to a build list with wrong content type."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -701,7 +736,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -711,7 +746,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -722,7 +757,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -731,10 +766,12 @@ class TestBuildListParts:
             "quantity": 1,
             "notes": "Test notes",
         }
+        auth_headers = headers.copy()
+        auth_headers["Content-Type"] = "text/plain"
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             content=str(build_list_part_data).encode(),
-            headers={"Content-Type": "text/plain"},
+            headers=auth_headers,
         )
         assert response.status_code == 422
 
@@ -742,8 +779,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test updating a build list part with extra fields in the request."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -751,7 +789,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -761,7 +799,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -772,7 +810,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -784,6 +822,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
         build_list_part = response.json()
@@ -797,6 +836,7 @@ class TestBuildListParts:
         response = client.put(
             f"{settings.API_STR}/build-list-parts/{build_list_part['id']}",
             json=update_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -808,57 +848,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test updating a build list part with malformed JSON."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
-
-        # Create a build list
-        build_list_data = {
-            "name": get_unique_name("test_build_list"),
-            "description": "A test build list description",
-        }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
-        assert response.status_code == 200
-        build_list = response.json()
-
-        # Create a global part
-        part_data = {
-            "name": get_unique_name("test_part"),
-            "description": "A test part description",
-            "price": 9999,
-            "category_id": test_category.id,
-        }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
-        assert response.status_code == 200
-        global_part = response.json()
-
-        # Add part to build list
-        build_list_part_data = {
-            "quantity": 1,
-            "notes": "Test notes",
-        }
-        response = client.post(
-            f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
-            json=build_list_part_data,
-        )
-        assert response.status_code == 200
-        build_list_part = response.json()
-
-        # Try to update with malformed JSON
-        response = client.put(
-            f"{settings.API_STR}/build-list-parts/{build_list_part['id']}",
-            content="invalid json",
-            headers={"Content-Type": "application/json"},
-        )
-        assert response.status_code == 422
-
-    def test_update_build_list_part_with_wrong_content_type(
-        self, client: TestClient, test_user: User, test_category: Category
-    ) -> None:
-        """Test updating a build list part with wrong content type."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -866,7 +858,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -876,7 +868,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -887,7 +879,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -899,6 +891,69 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
+        )
+        assert response.status_code == 200
+        build_list_part = response.json()
+
+        # Try to update with malformed JSON
+        auth_headers = headers.copy()
+        auth_headers["Content-Type"] = "application/json"
+        response = client.put(
+            f"{settings.API_STR}/build-list-parts/{build_list_part['id']}",
+            content="invalid json",
+            headers=auth_headers,
+        )
+        assert response.status_code == 422
+
+    def test_update_build_list_part_with_wrong_content_type(
+        self, client: TestClient, test_user: User, test_category: Category
+    ) -> None:
+        """Test updating a build list part with wrong content type."""
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
+
+        # Create a car first
+        car_data = {
+            "make": "Toyota",
+            "model": "Camry",
+            "year": 2020,
+        }
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
+        assert response.status_code == 200
+        car = response.json()
+
+        # Create a build list
+        build_list_data = {
+            "name": get_unique_name("test_build_list"),
+            "description": "A test build list description",
+            "car_id": car["id"],
+        }
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
+        assert response.status_code == 200
+        build_list = response.json()
+
+        # Create a global part
+        part_data = {
+            "name": get_unique_name("test_part"),
+            "description": "A test part description",
+            "price": 9999,
+            "category_id": test_category.id,
+        }
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
+        assert response.status_code == 200
+        global_part = response.json()
+
+        # Add part to build list
+        build_list_part_data = {
+            "quantity": 1,
+            "notes": "Test notes",
+        }
+        response = client.post(
+            f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
+            json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
         build_list_part = response.json()
@@ -908,10 +963,12 @@ class TestBuildListParts:
             "quantity": 3,
             "notes": "Updated notes",
         }
+        auth_headers = headers.copy()
+        auth_headers["Content-Type"] = "text/plain"
         response = client.put(
             f"{settings.API_STR}/build-list-parts/{build_list_part['id']}",
             content=str(update_data).encode(),
-            headers={"Content-Type": "text/plain"},
+            headers=auth_headers,
         )
         assert response.status_code == 422
 
@@ -952,7 +1009,8 @@ class TestBuildListParts:
         db_session.refresh(test_user)
 
         # Login as test user (this should work since email verification is checked later)
-        login_user(client, test_user.username)
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -960,7 +1018,7 @@ class TestBuildListParts:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 401  # Should fail due to unverified email
 
         # The test demonstrates that unverified email users cannot access protected endpoints
@@ -969,8 +1027,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test creating a global part and adding it to a build list in one operation."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -978,7 +1037,7 @@ class TestBuildListParts:
             "model": "Accord",
             "year": 2021,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -988,7 +1047,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -1003,6 +1062,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/create-and-add-part",
             json=part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -1016,8 +1076,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test getting global parts from a build list with full part details."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -1025,7 +1086,7 @@ class TestBuildListParts:
             "model": "Accord",
             "year": 2021,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -1035,7 +1096,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -1046,7 +1107,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -1058,11 +1119,12 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
         # Get global parts with full details
-        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts")
+        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts", headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -1078,8 +1140,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test updating a global part in a build list by build_list_id and global_part_id."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -1087,7 +1150,7 @@ class TestBuildListParts:
             "model": "Accord",
             "year": 2021,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -1097,7 +1160,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -1108,7 +1171,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -1120,6 +1183,7 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -1131,6 +1195,7 @@ class TestBuildListParts:
         response = client.put(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=update_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -1140,8 +1205,9 @@ class TestBuildListParts:
 
     def test_update_global_part_in_build_list_not_found(self, client: TestClient, test_user: User) -> None:
         """Test updating a non-existent global part in a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -1149,7 +1215,7 @@ class TestBuildListParts:
             "model": "Accord",
             "year": 2021,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -1159,7 +1225,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -1171,6 +1237,7 @@ class TestBuildListParts:
         response = client.put(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/99999",
             json=update_data,
+            headers=headers,
         )
         assert response.status_code == 404
 
@@ -1178,8 +1245,9 @@ class TestBuildListParts:
         self, client: TestClient, test_user: User, test_category: Category
     ) -> None:
         """Test removing a global part from a build list by build_list_id and global_part_id."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -1187,7 +1255,7 @@ class TestBuildListParts:
             "model": "Accord",
             "year": 2021,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -1197,7 +1265,7 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -1208,7 +1276,7 @@ class TestBuildListParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         global_part = response.json()
 
@@ -1220,25 +1288,28 @@ class TestBuildListParts:
         response = client.post(
             f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
             json=build_list_part_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
         # Remove the global part using build_list_id and global_part_id
         response = client.delete(
-            f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}"
+            f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/{global_part['id']}",
+            headers=headers,
         )
         assert response.status_code == 200
 
         # Verify the part was removed
-        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}")
+        response = client.get(f"{settings.API_STR}/build-list-parts/{build_list['id']}", headers=headers)
         assert response.status_code == 200
         data = response.json()
         assert len(data) == 0
 
     def test_remove_global_part_from_build_list_not_found(self, client: TestClient, test_user: User) -> None:
         """Test removing a non-existent global part from a build list."""
-        # Login as test user
-        login_user(client, test_user.username)
+        # Login as test user and get token
+        token = login_user(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -1246,7 +1317,7 @@ class TestBuildListParts:
             "model": "Accord",
             "year": 2021,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -1256,10 +1327,12 @@ class TestBuildListParts:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
         # Try to remove non-existent part
-        response = client.delete(f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/99999")
+        response = client.delete(
+            f"{settings.API_STR}/build-list-parts/{build_list['id']}/global-parts/99999", headers=headers
+        )
         assert response.status_code == 404

--- a/backend/tests/api/endpoints/test_build_lists.py
+++ b/backend/tests/api/endpoints/test_build_lists.py
@@ -15,22 +15,36 @@ def get_unique_name(base_name: str) -> str:
     return f"{base_name}_{worker_id}_{pid}"
 
 
+def get_auth_token(client: TestClient, username: str, password: str = "testpassword") -> str:
+    """Login and return the Bearer token for use in Authorization headers."""
+    login_data = {"username": username, "password": password}
+    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
+    assert response.status_code == 200
+    response_data = response.json()
+    assert "access_token" in response_data
+    return response_data["access_token"]
+
+
+def get_auth_headers(token: str) -> dict[str, str]:
+    """Get Authorization headers with Bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
 class TestBuildLists:
     """Test cases for build lists endpoints."""
 
     def test_create_build_list_success(self, client: TestClient, test_user: User) -> None:
         """Test successfully creating a build list."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("test_build_list"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -50,37 +64,34 @@ class TestBuildLists:
 
     def test_create_build_list_missing_name(self, client: TestClient, test_user: User) -> None:
         """Test creating a build list without providing a name."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Try to create a build list without name
         build_list_data = {"description": "A test build list description"}
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 422
 
     def test_create_build_list_empty_name(self, client: TestClient, test_user: User) -> None:
         """Test creating a build list with an empty name."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Try to create a build list with empty name
         build_list_data = {
             "name": "",
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 422
 
     def test_get_build_list_by_id(self, client: TestClient, test_user: User) -> None:
         """Test retrieving a specific build list by ID."""
-        # Login and create a build list
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -88,7 +99,7 @@ class TestBuildLists:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -98,12 +109,12 @@ class TestBuildLists:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         created_build_list = response.json()
 
         # Get the build list by ID
-        response = client.get(f"{settings.API_STR}/build-lists/{created_build_list['id']}")
+        response = client.get(f"{settings.API_STR}/build-lists/{created_build_list['id']}", headers=headers)
         assert response.status_code == 200
         data = response.json()
         assert data["id"] == created_build_list["id"]
@@ -112,12 +123,11 @@ class TestBuildLists:
     def test_get_build_list_not_found(self, client: TestClient, test_user: User) -> None:
         """Test retrieving a non-existent build list."""
         # Login first since the endpoint requires authentication
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Try to get a non-existent build list
-        response = client.get(f"{settings.API_STR}/build-lists/99999")
+        response = client.get(f"{settings.API_STR}/build-lists/99999", headers=headers)
         assert response.status_code == 404
 
     def test_get_build_list_unauthorized(self, client: TestClient) -> None:
@@ -128,10 +138,9 @@ class TestBuildLists:
 
     def test_get_user_build_lists(self, client: TestClient, test_user: User) -> None:
         """Test retrieving build lists for the current user."""
-        # Login and create a build list
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -139,7 +148,7 @@ class TestBuildLists:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -149,11 +158,11 @@ class TestBuildLists:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
 
         # Get user's build lists
-        response = client.get(f"{settings.API_STR}/build-lists/user/me")
+        response = client.get(f"{settings.API_STR}/build-lists/user/me", headers=headers)
         assert response.status_code == 200
         data: list[Any] = response.json()
         assert isinstance(data, list)
@@ -166,10 +175,9 @@ class TestBuildLists:
 
     def test_update_build_list_success(self, client: TestClient, test_user: User) -> None:
         """Test updating a build list."""
-        # Login and create a build list
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -177,7 +185,7 @@ class TestBuildLists:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -187,7 +195,7 @@ class TestBuildLists:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         created_build_list = response.json()
 
@@ -199,6 +207,7 @@ class TestBuildLists:
         response = client.put(
             f"{settings.API_STR}/build-lists/{created_build_list['id']}",
             json=update_data,
+            headers=headers,
         )
         assert response.status_code == 200
         data = response.json()
@@ -214,10 +223,9 @@ class TestBuildLists:
 
     def test_delete_build_list_success(self, client: TestClient, test_user: User) -> None:
         """Test deleting a build list."""
-        # Login and create a build list
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -225,7 +233,7 @@ class TestBuildLists:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -235,16 +243,16 @@ class TestBuildLists:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         created_build_list = response.json()
 
         # Delete the build list
-        response = client.delete(f"{settings.API_STR}/build-lists/{created_build_list['id']}")
+        response = client.delete(f"{settings.API_STR}/build-lists/{created_build_list['id']}", headers=headers)
         assert response.status_code == 200
 
         # Verify it's deleted
-        response = client.get(f"{settings.API_STR}/build-lists/{created_build_list['id']}")
+        response = client.get(f"{settings.API_STR}/build-lists/{created_build_list['id']}", headers=headers)
         assert response.status_code == 404
 
     def test_delete_build_list_unauthorized(self, client: TestClient) -> None:
@@ -255,10 +263,9 @@ class TestBuildLists:
 
     def test_get_build_lists_by_car(self, client: TestClient, test_user: User) -> None:
         """Test retrieving build lists for a specific car."""
-        # Login and create a build list
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a car first
         car_data = {
@@ -266,7 +273,7 @@ class TestBuildLists:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -276,11 +283,11 @@ class TestBuildLists:
             "description": "A test build list description",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
 
         # Get build lists for the car
-        response = client.get(f"{settings.API_STR}/build-lists/car/{car['id']}")
+        response = client.get(f"{settings.API_STR}/build-lists/car/{car['id']}", headers=headers)
         assert response.status_code == 200
         data: list[Any] = response.json()
         assert isinstance(data, list)
@@ -292,32 +299,27 @@ class TestBuildLists:
     def test_get_build_lists_by_car_unauthorized(self, client: TestClient, test_user: User) -> None:
         """Test retrieving build lists for a car owned by another user."""
         # Create a car as test_user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         car_data = {
             "make": "Toyota",
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
-        # Clear cookies to simulate different user
-        client.cookies.clear()
-
-        # Try to get build lists for another user's car
+        # Try to get build lists for another user's car without authentication
         response = client.get(f"{settings.API_STR}/build-lists/car/{car['id']}")
         assert response.status_code == 401
 
     def test_create_build_list_with_extra_fields(self, client: TestClient, test_user: User) -> None:
         """Test creating a build list with extra fields in the request."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a build list with extra fields
         build_list_data = {
@@ -325,7 +327,7 @@ class TestBuildLists:
             "description": "A test build list description",
             "extra_field": "should_be_ignored",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -334,25 +336,25 @@ class TestBuildLists:
 
     def test_create_build_list_with_malformed_json(self, client: TestClient, test_user: User) -> None:
         """Test creating a build list with malformed JSON."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
+        headers["Content-Type"] = "application/json"
 
         # Try to create a build list with malformed JSON
         response = client.post(
             f"{settings.API_STR}/build-lists/",
             content="invalid json",
-            headers={"Content-Type": "application/json"},
+            headers=headers,
         )
         assert response.status_code == 422
 
     def test_create_build_list_with_wrong_content_type(self, client: TestClient, test_user: User) -> None:
         """Test creating a build list with wrong content type."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
+        headers["Content-Type"] = "text/plain"
 
         # Try to create a build list with wrong content type
         build_list_data = {
@@ -362,23 +364,22 @@ class TestBuildLists:
         response = client.post(
             f"{settings.API_STR}/build-lists/",
             data=build_list_data,
-            headers={"Content-Type": "text/plain"},
+            headers=headers,
         )
         assert response.status_code == 422
 
     def test_update_build_list_with_extra_fields(self, client: TestClient, test_user: User) -> None:
         """Test updating a build list with extra fields in the request."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("test_build_list"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -388,7 +389,7 @@ class TestBuildLists:
             "description": "An updated build list description",
             "extra_field": "should_be_ignored",
         }
-        response = client.put(f"{settings.API_STR}/build-lists/{build_list['id']}", json=update_data)
+        response = client.put(f"{settings.API_STR}/build-lists/{build_list['id']}", json=update_data, headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -397,41 +398,41 @@ class TestBuildLists:
 
     def test_update_build_list_with_malformed_json(self, client: TestClient, test_user: User) -> None:
         """Test updating a build list with malformed JSON."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("test_build_list"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
         # Try to update with malformed JSON
+        update_headers = get_auth_headers(token)
+        update_headers["Content-Type"] = "application/json"
         response = client.put(
             f"{settings.API_STR}/build-lists/{build_list['id']}",
             content="invalid json",
-            headers={"Content-Type": "application/json"},
+            headers=update_headers,
         )
         assert response.status_code == 422
 
     def test_update_build_list_with_wrong_content_type(self, client: TestClient, test_user: User) -> None:
         """Test updating a build list with wrong content type."""
-        # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        # Login as test user and get token
+        token = get_auth_token(client, test_user.username)
+        headers = get_auth_headers(token)
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("test_build_list"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
         build_list = response.json()
 
@@ -440,10 +441,12 @@ class TestBuildLists:
             "name": get_unique_name("updated_build_list"),
             "description": "An updated build list description",
         }
+        update_headers = get_auth_headers(token)
+        update_headers["Content-Type"] = "text/plain"
         response = client.put(
             f"{settings.API_STR}/build-lists/{build_list['id']}",
             data=update_data,
-            headers={"Content-Type": "text/plain"},
+            headers=update_headers,
         )
         assert response.status_code == 422
 
@@ -473,17 +476,24 @@ class TestBuildLists:
         db_session.commit()
         db_session.refresh(test_user)
 
-        # Login as test user (this should work since email verification is checked later)
+        # Login as test user (this should work since email verification is checked in get_current_user)
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
 
+        # Extract token from login response
+        token_data = response.json()
+        assert "access_token" in token_data
+        token = token_data["access_token"]
+        headers = get_auth_headers(token)
+
         # Try to create a build list with unverified email user
+        # Even though login succeeded, the token should be invalid for protected endpoints
         build_list_data = {
             "name": get_unique_name("test_build_list"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 401  # Should fail due to unverified email
 
         # The test demonstrates that unverified email users cannot access protected endpoints

--- a/backend/tests/api/endpoints/test_cars.py
+++ b/backend/tests/api/endpoints/test_cars.py
@@ -6,11 +6,10 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 
 
-# Helper function to create a user and log them in (sets cookie on client)
-# This function is similar to the one in test_build_lists.py
+# Helper function to create a user and log them in (returns user_id and token)
 def create_and_login_user(
     client: TestClient, username_suffix: str, db_session: Session | None = None
-) -> int:  # Returns user_id
+) -> tuple[int, str]:  # Returns (user_id, token)
     username = f"car_test_user_{username_suffix}"
     email = f"car_test_user_{username_suffix}@example.com"
     password = "testpassword"
@@ -40,14 +39,19 @@ def create_and_login_user(
         response.raise_for_status()  # Raise an exception for other errors
 
     login_data = {"username": username, "password": password}
-    token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)  # Changed
+    token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     if token_response.status_code != 200:
         raise Exception(
             f"Failed to log in user {username}. Status: {token_response.status_code}, Detail: {token_response.text}"
         )
 
+    token_data = token_response.json()
+    assert "access_token" in token_data
+    token = token_data["access_token"]
+
     if user_id == -1:  # If user existed and was not created, fetch ID
-        me_response = client.get(f"{settings.API_STR}/users/me")
+        headers = {"Authorization": f"Bearer {token}"}
+        me_response = client.get(f"{settings.API_STR}/users/me", headers=headers)
         if me_response.status_code == 200:
             user_id = me_response.json()["id"]
         else:
@@ -55,17 +59,23 @@ def create_and_login_user(
 
     if user_id == -1:
         raise Exception(f"User ID for {username} could not be determined.")
-    return user_id
+    return (user_id, token)
+
+
+def get_auth_headers(token: str) -> dict[str, str]:
+    """Get Authorization headers with Bearer token."""
+    return {"Authorization": f"Bearer {token}"}
 
 
 # --- Test Cases ---
 
 
 def test_create_car_success(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "creator_car", db_session)  # Logs in user, client gets cookie
+    _, token = create_and_login_user(client, "creator_car", db_session)  # Returns user_id and token
+    headers = get_auth_headers(token)
 
     car_data = {"make": "Honda", "model": "Civic", "year": 2022, "trim": "Sport"}
-    response = client.post(f"{settings.API_STR}/cars/", json=car_data)  # Cookie sent automatically
+    response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
     assert response.status_code == 200, response.text
     created_car = response.json()
     assert created_car["make"] == car_data["make"]
@@ -82,9 +92,10 @@ def test_create_car_unauthenticated(client: TestClient, db_session: Session) -> 
 
 
 def test_read_car_success(client: TestClient, db_session: Session) -> None:
-    user_id = create_and_login_user(client, "reader_car", db_session)  # Returns user_id directly
+    user_id, token = create_and_login_user(client, "reader_car", db_session)  # Returns user_id and token
+    headers = get_auth_headers(token)
     car_data_payload = {"make": "Mazda", "model": "3", "year": 2020}
-    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data_payload)
+    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data_payload, headers=headers)
     assert create_response.status_code == 200
     car_id = create_response.json()["id"]
 
@@ -106,15 +117,16 @@ def test_read_car_not_found(client: TestClient, db_session: Session) -> None:
 
 
 def test_update_own_car_success(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "updater_car", db_session)  # Logs in, client gets cookie
+    _, token = create_and_login_user(client, "updater_car", db_session)
+    headers = get_auth_headers(token)
 
     initial_car_data = {"make": "Nissan", "model": "Altima", "year": 2019}
-    create_response = client.post(f"{settings.API_STR}/cars/", json=initial_car_data)
+    create_response = client.post(f"{settings.API_STR}/cars/", json=initial_car_data, headers=headers)
     assert create_response.status_code == 200
     car_id = create_response.json()["id"]
 
     update_payload = {"model": "Maxima", "year": 2020}
-    response = client.put(f"{settings.API_STR}/cars/{car_id}", json=update_payload)  # Cookie sent
+    response = client.put(f"{settings.API_STR}/cars/{car_id}", json=update_payload, headers=headers)
     assert response.status_code == 200, response.text
     updated_car = response.json()
     assert updated_car["model"] == update_payload["model"]
@@ -123,13 +135,14 @@ def test_update_own_car_success(client: TestClient, db_session: Session) -> None
 
 
 def test_update_car_unauthenticated(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "owner_for_update_unauth_car", db_session)
+    _, token = create_and_login_user(client, "owner_for_update_unauth_car", db_session)
+    headers = get_auth_headers(token)
     car_data = {"make": "Subaru", "model": "WRX", "year": 2021}
-    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
     assert create_response.status_code == 200
     car_id = create_response.json()["id"]
 
-    client.cookies.clear()  # Clear cookie for unauthenticated request
+    # Try to update without authentication
     update_payload = {"year": 2022}
     response = client.put(f"{settings.API_STR}/cars/{car_id}", json=update_payload)
     assert response.status_code == 401
@@ -137,67 +150,72 @@ def test_update_car_unauthenticated(client: TestClient, db_session: Session) -> 
 
 def test_update_other_users_car_forbidden(client: TestClient, db_session: Session) -> None:
     # User A creates a car
-    _ = create_and_login_user(client, "userA_car_owner", db_session)  # Client has User A's cookie
+    _, token_a = create_and_login_user(client, "userA_car_owner", db_session)
+    headers_a = get_auth_headers(token_a)
     car_data_a = {"make": "Ford", "model": "Focus", "year": 2018}
-    create_response_a = client.post(f"{settings.API_STR}/cars/", json=car_data_a)
+    create_response_a = client.post(f"{settings.API_STR}/cars/", json=car_data_a, headers=headers_a)
     assert create_response_a.status_code == 200
     car_id_a = create_response_a.json()["id"]
 
-    # User B logs in (client now has User B's cookie)
-    client.cookies.clear()
-    _ = create_and_login_user(client, "userB_car_attacker", db_session)
+    # User B logs in
+    _, token_b = create_and_login_user(client, "userB_car_attacker", db_session)
+    headers_b = get_auth_headers(token_b)
 
     update_payload = {"year": 2023}
     response = client.put(
-        f"{settings.API_STR}/cars/{car_id_a}", json=update_payload
+        f"{settings.API_STR}/cars/{car_id_a}", json=update_payload, headers=headers_b
     )  # User B tries to update User A's car
     assert response.status_code == 403  # Expect forbidden
     assert response.json()["message"] == "Not authorized to perform this action on this car"
 
 
 def test_delete_own_car_success(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "deleter_car", db_session)  # Logs in, client gets cookie
+    _, token = create_and_login_user(client, "deleter_car", db_session)
+    headers = get_auth_headers(token)
     car_data = {"make": "Kia", "model": "Stinger", "year": 2020}
-    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
     assert create_response.status_code == 200
     car_id = create_response.json()["id"]
 
-    response = client.delete(f"{settings.API_STR}/cars/{car_id}")  # Cookie sent
+    response = client.delete(f"{settings.API_STR}/cars/{car_id}", headers=headers)
     assert response.status_code == 200, response.text
     deleted_car_data = response.json()
     assert deleted_car_data["id"] == car_id
 
-    # Verify car is deleted
-    client.cookies.clear()  # Clear cookie to ensure public 404 if car is gone
+    # Verify car is deleted (public endpoint, no auth needed)
     get_response = client.get(f"{settings.API_STR}/cars/{car_id}")
     assert get_response.status_code == 404
 
 
 def test_delete_car_unauthenticated(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "owner_for_delete_unauth_car", db_session)
+    _, token = create_and_login_user(client, "owner_for_delete_unauth_car", db_session)
+    headers = get_auth_headers(token)
     car_data = {"make": "Hyundai", "model": "Elantra", "year": 2019}
-    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+    create_response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
     assert create_response.status_code == 200
     car_id = create_response.json()["id"]
 
-    client.cookies.clear()  # Clear cookie
+    # Try to delete without authentication
     response = client.delete(f"{settings.API_STR}/cars/{car_id}")
     assert response.status_code == 401
 
 
 def test_delete_other_users_car_forbidden(client: TestClient, db_session: Session) -> None:
     # User A creates a car
-    _ = create_and_login_user(client, "userA_car_owner_del", db_session)  # Client has User A's cookie
+    _, token_a = create_and_login_user(client, "userA_car_owner_del", db_session)
+    headers_a = get_auth_headers(token_a)
     car_data_a = {"make": "BMW", "model": "M3", "year": 2021}
-    create_response_a = client.post(f"{settings.API_STR}/cars/", json=car_data_a)
+    create_response_a = client.post(f"{settings.API_STR}/cars/", json=car_data_a, headers=headers_a)
     assert create_response_a.status_code == 200
     car_id_a = create_response_a.json()["id"]
 
     # User B logs in
-    client.cookies.clear()
-    _ = create_and_login_user(client, "userB_car_deleter_attacker", db_session)  # Client has User B's cookie
+    _, token_b = create_and_login_user(client, "userB_car_deleter_attacker", db_session)
+    headers_b = get_auth_headers(token_b)
 
-    response = client.delete(f"{settings.API_STR}/cars/{car_id_a}")  # User B tries to delete User A's car
+    response = client.delete(
+        f"{settings.API_STR}/cars/{car_id_a}", headers=headers_b
+    )  # User B tries to delete User A's car
     assert response.status_code == 403
     # The delete endpoint uses the base router which returns a different message
     assert "Not authorized" in response.json()["message"]
@@ -205,16 +223,18 @@ def test_delete_other_users_car_forbidden(client: TestClient, db_session: Sessio
 
 
 def test_update_car_not_found(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "updater_car_notfound", db_session)  # Sets cookie
+    _, token = create_and_login_user(client, "updater_car_notfound", db_session)
+    headers = get_auth_headers(token)
     update_payload = {"make": "NonExistent"}
-    response = client.put(f"{settings.API_STR}/cars/888888", json=update_payload)  # Uses cookie
+    response = client.put(f"{settings.API_STR}/cars/888888", json=update_payload, headers=headers)
     assert response.status_code == 404
     assert response.json()["message"] == "Car not found"
 
 
 def test_delete_car_not_found(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "deleter_car_notfound", db_session)  # Sets cookie
-    response = client.delete(f"{settings.API_STR}/cars/777777")  # Uses cookie, Non-existent ID
+    _, token = create_and_login_user(client, "deleter_car_notfound", db_session)
+    headers = get_auth_headers(token)
+    response = client.delete(f"{settings.API_STR}/cars/777777", headers=headers)  # Non-existent ID
     assert response.status_code == 404
     assert response.json()["message"] == "Car not found"
 
@@ -224,12 +244,13 @@ def test_delete_car_not_found(client: TestClient, db_session: Session) -> None:
 
 def test_read_cars_by_user_success(client: TestClient, db_session: Session) -> None:
     # Create a user and log them in to create cars
-    user_id = create_and_login_user(client, "car_owner_for_list", db_session)  # Returns user_id directly
+    user_id, token = create_and_login_user(client, "car_owner_for_list", db_session)
+    headers = get_auth_headers(token)
 
     # Create a car for this user (reduced to 1 to avoid subscription limits)
     car_data1 = {"make": "Toyota", "model": "Supra", "year": 1998}
 
-    response1 = client.post(f"{settings.API_STR}/cars/", json=car_data1)  # Uses cookie
+    response1 = client.post(f"{settings.API_STR}/cars/", json=car_data1, headers=headers)
     assert response1.status_code == 200
     car_id1 = response1.json()["id"]
 
@@ -255,10 +276,9 @@ def test_read_cars_by_user_success(client: TestClient, db_session: Session) -> N
 
 def test_read_cars_by_user_no_cars(client: TestClient, db_session: Session) -> None:
     # Create a user but no cars for them
-    user_id = create_and_login_user(client, "car_owner_no_cars", db_session)  # Returns user_id directly
+    user_id, _ = create_and_login_user(client, "car_owner_no_cars", db_session)
 
-    # Clear cookies as the endpoint is public
-    client.cookies.clear()
+    # Endpoint is public, no auth needed
     response = client.get(f"{settings.API_STR}/cars/user/{user_id}")
     assert response.status_code == 200, response.text
 
@@ -283,7 +303,8 @@ def test_read_cars_by_user_non_existent_user(client: TestClient, db_session: Ses
 def test_read_cars_by_user_pagination(client: TestClient, db_session: Session) -> None:
     """Test pagination for cars by user."""
     # Create a user and log them in to create cars
-    user_id = create_and_login_user(client, "car_owner_for_pagination", db_session)  # Returns user_id directly
+    user_id, token = create_and_login_user(client, "car_owner_for_pagination", db_session)
+    headers = get_auth_headers(token)
 
     # Create multiple cars for this user (reduced to 2 to avoid subscription limits)
     car_ids: List[int] = []
@@ -293,12 +314,11 @@ def test_read_cars_by_user_pagination(client: TestClient, db_session: Session) -
             "model": f"Model{i}",
             "year": 2000 + i,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car_ids.append(response.json()["id"])
 
-    # Clear cookies as the endpoint is public
-    client.cookies.clear()
+    # Endpoint is public, no auth needed
 
     # Test first page (limit=1, skip=0)
     response = client.get(f"{settings.API_STR}/cars/user/{user_id}?limit=1&skip=0")
@@ -333,26 +353,26 @@ def test_read_cars_by_user_pagination(client: TestClient, db_session: Session) -
 def test_get_cars_by_make_success(client: TestClient, db_session: Session) -> None:
     """Test getting cars by make."""
     # Create a user and add multiple cars
-    _ = create_and_login_user(client, "car_make_user", db_session)
+    _, token = create_and_login_user(client, "car_make_user", db_session)
+    headers = get_auth_headers(token)
 
     # Create Toyota cars
     toyota1_data = {"make": "Toyota", "model": "Camry", "year": 2020}
     toyota2_data = {"make": "Toyota", "model": "Corolla", "year": 2021}
     honda_data = {"make": "Honda", "model": "Civic", "year": 2020}
 
-    toyota1_response = client.post(f"{settings.API_STR}/cars/", json=toyota1_data)
+    toyota1_response = client.post(f"{settings.API_STR}/cars/", json=toyota1_data, headers=headers)
     assert toyota1_response.status_code == 200
     toyota1_id = toyota1_response.json()["id"]
 
-    toyota2_response = client.post(f"{settings.API_STR}/cars/", json=toyota2_data)
+    toyota2_response = client.post(f"{settings.API_STR}/cars/", json=toyota2_data, headers=headers)
     assert toyota2_response.status_code == 200
     toyota2_id = toyota2_response.json()["id"]
 
-    honda_response = client.post(f"{settings.API_STR}/cars/", json=honda_data)
+    honda_response = client.post(f"{settings.API_STR}/cars/", json=honda_data, headers=headers)
     assert honda_response.status_code == 200
 
-    # Clear cookies for public endpoint access
-    client.cookies.clear()
+    # Endpoint is public, no auth needed
 
     # Get cars by make "Toyota"
     response = client.get(f"{settings.API_STR}/cars/make/Toyota")
@@ -384,13 +404,14 @@ def test_get_cars_by_make_no_results(client: TestClient, db_session: Session) ->
 
 def test_get_cars_by_make_pagination(client: TestClient, db_session: Session) -> None:
     """Test pagination for cars by make."""
-    _ = create_and_login_user(client, "car_make_pagination_user", db_session)
+    _, token = create_and_login_user(client, "car_make_pagination_user", db_session)
+    headers = get_auth_headers(token)
 
     # Create multiple Ford cars
     ford_ids: List[int] = []
     for i in range(2):
         ford_data = {"make": "Ford", "model": f"Model{i}", "year": 2020 + i}
-        response = client.post(f"{settings.API_STR}/cars/", json=ford_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=ford_data, headers=headers)
         assert response.status_code == 200
         ford_ids.append(response.json()["id"])
 
@@ -409,22 +430,23 @@ def test_get_cars_by_make_pagination(client: TestClient, db_session: Session) ->
 
 def test_get_cars_by_year_success(client: TestClient, db_session: Session) -> None:
     """Test getting cars by year."""
-    _ = create_and_login_user(client, "car_year_user", db_session)
+    _, token = create_and_login_user(client, "car_year_user", db_session)
+    headers = get_auth_headers(token)
 
     # Create cars with specific years
     car_2020_1_data = {"make": "Toyota", "model": "Camry", "year": 2020}
     car_2020_2_data = {"make": "Honda", "model": "Civic", "year": 2020}
     car_2021_data = {"make": "Ford", "model": "Focus", "year": 2021}
 
-    car_2020_1_response = client.post(f"{settings.API_STR}/cars/", json=car_2020_1_data)
+    car_2020_1_response = client.post(f"{settings.API_STR}/cars/", json=car_2020_1_data, headers=headers)
     assert car_2020_1_response.status_code == 200
     car_2020_1_id = car_2020_1_response.json()["id"]
 
-    car_2020_2_response = client.post(f"{settings.API_STR}/cars/", json=car_2020_2_data)
+    car_2020_2_response = client.post(f"{settings.API_STR}/cars/", json=car_2020_2_data, headers=headers)
     assert car_2020_2_response.status_code == 200
     car_2020_2_id = car_2020_2_response.json()["id"]
 
-    car_2021_response = client.post(f"{settings.API_STR}/cars/", json=car_2021_data)
+    car_2021_response = client.post(f"{settings.API_STR}/cars/", json=car_2021_data, headers=headers)
     assert car_2021_response.status_code == 200
 
     client.cookies.clear()
@@ -462,17 +484,18 @@ def test_get_cars_by_year_no_results(client: TestClient, db_session: Session) ->
 
 def test_search_cars_by_make(client: TestClient, db_session: Session) -> None:
     """Test searching cars by make."""
-    _ = create_and_login_user(client, "car_search_user", db_session)
+    _, token = create_and_login_user(client, "car_search_user", db_session)
+    headers = get_auth_headers(token)
 
     # Create cars with searchable names
     tesla_data = {"make": "Tesla", "model": "Model 3", "year": 2021}
     toyota_data = {"make": "Toyota", "model": "Corolla", "year": 2020}
 
-    tesla_response = client.post(f"{settings.API_STR}/cars/", json=tesla_data)
+    tesla_response = client.post(f"{settings.API_STR}/cars/", json=tesla_data, headers=headers)
     assert tesla_response.status_code == 200
     tesla_id = tesla_response.json()["id"]
 
-    client.post(f"{settings.API_STR}/cars/", json=toyota_data)
+    client.post(f"{settings.API_STR}/cars/", json=toyota_data, headers=headers)
 
     client.cookies.clear()
 
@@ -491,11 +514,12 @@ def test_search_cars_by_make(client: TestClient, db_session: Session) -> None:
 
 def test_search_cars_by_model(client: TestClient, db_session: Session) -> None:
     """Test searching cars by model."""
-    _ = create_and_login_user(client, "car_search_model_user", db_session)
+    _, token = create_and_login_user(client, "car_search_model_user", db_session)
+    headers = get_auth_headers(token)
 
     # Create cars with specific models
     car_data = {"make": "BMW", "model": "M3", "year": 2022}
-    car_response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+    car_response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
     assert car_response.status_code == 200
     car_id = car_response.json()["id"]
 
@@ -542,7 +566,8 @@ def test_get_car_make_stats(client: TestClient, db_session: Session) -> None:
     import os
 
     # Login as test user
-    _ = create_and_login_user(client, f"stats_test_make_{os.getpid()}", db_session)
+    _, token = create_and_login_user(client, f"stats_test_make_{os.getpid()}", db_session)
+    headers = get_auth_headers(token)
 
     # Create cars with different makes
     car_data_honda1 = {
@@ -562,9 +587,9 @@ def test_get_car_make_stats(client: TestClient, db_session: Session) -> None:
     }
 
     # Create the cars
-    client.post(f"{settings.API_STR}/cars/", json=car_data_honda1)
-    client.post(f"{settings.API_STR}/cars/", json=car_data_honda2)
-    client.post(f"{settings.API_STR}/cars/", json=car_data_toyota)
+    client.post(f"{settings.API_STR}/cars/", json=car_data_honda1, headers=headers)
+    client.post(f"{settings.API_STR}/cars/", json=car_data_honda2, headers=headers)
+    client.post(f"{settings.API_STR}/cars/", json=car_data_toyota, headers=headers)
 
     # Get make statistics
     response = client.get(f"{settings.API_STR}/cars/stats/makes")
@@ -581,7 +606,8 @@ def test_get_car_year_stats(client: TestClient, db_session: Session) -> None:
     import os
 
     # Login as test user
-    _ = create_and_login_user(client, f"stats_test_year_{os.getpid()}", db_session)
+    _, token = create_and_login_user(client, f"stats_test_year_{os.getpid()}", db_session)
+    headers = get_auth_headers(token)
 
     # Create cars with different years
     car_data_2020 = {
@@ -601,9 +627,9 @@ def test_get_car_year_stats(client: TestClient, db_session: Session) -> None:
     }
 
     # Create the cars
-    client.post(f"{settings.API_STR}/cars/", json=car_data_2020)
-    client.post(f"{settings.API_STR}/cars/", json=car_data_2021_1)
-    client.post(f"{settings.API_STR}/cars/", json=car_data_2021_2)
+    client.post(f"{settings.API_STR}/cars/", json=car_data_2020, headers=headers)
+    client.post(f"{settings.API_STR}/cars/", json=car_data_2021_1, headers=headers)
+    client.post(f"{settings.API_STR}/cars/", json=car_data_2021_2, headers=headers)
 
     # Get year statistics
     response = client.get(f"{settings.API_STR}/cars/stats/years")

--- a/backend/tests/api/endpoints/test_categories.py
+++ b/backend/tests/api/endpoints/test_categories.py
@@ -13,8 +13,8 @@ from tests.conftest import get_default_category_id
 # Helper function to create and login an admin user
 def create_and_login_admin_user(
     client: TestClient, db_session: Session, username_suffix: str = "admin"
-) -> dict[str, Any]:
-    """Create an admin user and log them in."""
+) -> tuple[dict[str, Any], str]:
+    """Create an admin user and log them in. Returns (user_dict, token)."""
     username = f"admin_test_{username_suffix}"
     email = f"admin_test_{username_suffix}@example.com"
     password = "testpassword"
@@ -33,16 +33,17 @@ def create_and_login_admin_user(
     db_session.commit()
     db_session.refresh(admin_user)
 
-    # Log in to set cookie on the client
+    # Log in and get token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert token_response.status_code == 200, f"Failed to login admin user: {token_response.text}"
+    token = token_response.json()["access_token"]
 
-    return admin_user.__dict__
+    return admin_user.__dict__, token
 
 
-# Helper function to create a user and log them in (sets cookie on client)
-def create_and_login_user(client: TestClient, username_suffix: str) -> int:  # Returns user_id
+# Helper function to create a user and log them in. Returns (user_id, token)
+def create_and_login_user(client: TestClient, username_suffix: str) -> tuple[int, str]:
     username = f"category_test_user_{username_suffix}"
     email = f"category_test_user_{username_suffix}@example.com"
     password = "testpassword"
@@ -67,9 +68,11 @@ def create_and_login_user(client: TestClient, username_suffix: str) -> int:  # R
         raise Exception(
             f"Failed to log in user {username}. Status: {token_response.status_code}, Detail: {token_response.text}"
         )
+    token = token_response.json()["access_token"]
 
     if user_id == -1:
-        me_response = client.get(f"{settings.API_STR}/users/me")
+        headers = {"Authorization": f"Bearer {token}"}
+        me_response = client.get(f"{settings.API_STR}/users/me", headers=headers)
         if me_response.status_code == 200:
             user_id = me_response.json()["id"]
         else:
@@ -77,34 +80,39 @@ def create_and_login_user(client: TestClient, username_suffix: str) -> int:  # R
 
     if user_id == -1:
         raise Exception(f"User ID for {username} could not be determined.")
-    return user_id
+    return user_id, token
 
 
-# Helper function to create a car for the currently logged-in user (via client cookie)
+# Helper function to create a car for the currently logged-in user
 def create_car_for_user_cookie_auth(
     client: TestClient,
+    token: str,
     car_make: str = "TestMakeCategory",
     car_model: str = "TestModelCategory",
 ) -> int:
+    headers = {"Authorization": f"Bearer {token}"}
     car_data = {
         "make": car_make,
         "model": car_model,
         "year": 2024,
         "trim": "TestTrimCategory",
     }
-    response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+    response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
     assert response.status_code == 200, f"Failed to create car for category tests: {response.text}"
     return int(response.json()["id"])
 
 
 # Helper function to create a build list for a car owned by the currently logged-in user
-def create_build_list_for_car_cookie_auth(client: TestClient, car_id: int, bl_name: str = "TestBLCategory") -> int:
+def create_build_list_for_car_cookie_auth(
+    client: TestClient, token: str, car_id: int, bl_name: str = "TestBLCategory"
+) -> int:
+    headers = {"Authorization": f"Bearer {token}"}
     build_list_data = {
         "name": bl_name,
         "description": "Test BL for categories",
         "car_id": car_id,
     }
-    response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+    response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
     assert response.status_code == 200, f"Failed to create build list for category tests: {response.text}"
     return int(response.json()["id"])
 
@@ -175,13 +183,14 @@ class TestCategories:
         category_id = get_default_category_id(db_session)
 
         # Create a user and log them in
-        _ = create_and_login_user(client, "parts_by_category")
+        _, token = create_and_login_user(client, "parts_by_category")
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Create a car for the user
-        car_id = create_car_for_user_cookie_auth(client)
+        car_id = create_car_for_user_cookie_auth(client, token)
 
         # Create a build list for the car
-        build_list_id = create_build_list_for_car_cookie_auth(client, car_id)
+        build_list_id = create_build_list_for_car_cookie_auth(client, token, car_id)
 
         # Create some parts in the category
         for i in range(3):
@@ -192,7 +201,7 @@ class TestCategories:
                 "build_list_id": build_list_id,
                 "category_id": category_id,
             }
-            response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+            response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
             assert response.status_code == 200
 
         response = client.get(f"{settings.API_STR}/categories/{category_id}/global-parts?skip=2&limit=2")
@@ -217,7 +226,8 @@ class TestCategories:
     def test_create_category_success(self, client: TestClient, db_session: Session) -> None:
         """Test creating a new category."""
         # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "create_cat")
+        _, token = create_and_login_admin_user(client, db_session, "create_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         category_data = {
             "name": "test_category",
@@ -228,7 +238,7 @@ class TestCategories:
             "sort_order": 50,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 200
 
         category = response.json()
@@ -242,7 +252,8 @@ class TestCategories:
     def test_create_category_duplicate_name(self, client: TestClient, db_session: Session) -> None:
         """Test creating a category with duplicate name."""
         # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "duplicate_cat")
+        _, token = create_and_login_admin_user(client, db_session, "duplicate_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         # First create a category
         category_data = {
@@ -253,18 +264,19 @@ class TestCategories:
             "sort_order": 50,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 200
 
         # Try to create another category with the same name
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 409  # 409 Conflict is correct for duplicates
         assert "already exists" in response.json()["message"]
 
     def test_update_category_success(self, client: TestClient, db_session: Session) -> None:
         """Test updating a category."""
         # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "update_cat")
+        _, token = create_and_login_admin_user(client, db_session, "update_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         # First create a category
         category_data = {
@@ -275,7 +287,7 @@ class TestCategories:
             "sort_order": 50,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 200
         category_id = response.json()["id"]
 
@@ -286,7 +298,7 @@ class TestCategories:
             "sort_order": 60,
         }
 
-        response = client.put(f"{settings.API_STR}/categories/{category_id}", json=update_data)
+        response = client.put(f"{settings.API_STR}/categories/{category_id}", json=update_data, headers=headers)
         assert response.status_code == 200
 
         category = response.json()
@@ -300,18 +312,20 @@ class TestCategories:
     def test_update_category_not_found(self, client: TestClient, db_session: Session) -> None:
         """Test updating a non-existent category."""
         # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "update_not_found")
+        _, token = create_and_login_admin_user(client, db_session, "update_not_found")
+        headers = {"Authorization": f"Bearer {token}"}
 
         update_data = {"display_name": "Updated Test Category"}
 
-        response = client.put(f"{settings.API_STR}/categories/99999", json=update_data)
+        response = client.put(f"{settings.API_STR}/categories/99999", json=update_data, headers=headers)
         assert response.status_code == 404
         assert "category" in response.json()["message"].lower() and "not found" in response.json()["message"].lower()
 
     def test_delete_category_success(self, client: TestClient, db_session: Session) -> None:
         """Test deleting a category."""
         # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_cat")
+        _, token = create_and_login_admin_user(client, db_session, "delete_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         # First create a category
         category_data = {
@@ -322,12 +336,12 @@ class TestCategories:
             "sort_order": 50,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 200
         category_id = response.json()["id"]
 
         # Delete the category
-        response = client.delete(f"{settings.API_STR}/categories/{category_id}")
+        response = client.delete(f"{settings.API_STR}/categories/{category_id}", headers=headers)
         assert response.status_code == 200
 
         # Verify the category is deleted
@@ -337,9 +351,10 @@ class TestCategories:
     def test_delete_category_not_found(self, client: TestClient, db_session: Session) -> None:
         """Test deleting a non-existent category."""
         # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_not_found")
+        _, token = create_and_login_admin_user(client, db_session, "delete_not_found")
+        headers = {"Authorization": f"Bearer {token}"}
 
-        response = client.delete(f"{settings.API_STR}/categories/99999")
+        response = client.delete(f"{settings.API_STR}/categories/99999", headers=headers)
         assert response.status_code == 404
         response_data = response.json()
         # Check that the error message indicates category not found (flexible matching)
@@ -348,17 +363,18 @@ class TestCategories:
 
     def test_delete_category_with_parts(self, client: TestClient, db_session: Session) -> None:
         """Test deleting a category that has parts (should fail)."""
-        # Create and login as admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_with_parts")
+        # Create and login as admin user (not used here, but kept for test setup clarity)
+        _, _ = create_and_login_admin_user(client, db_session, "delete_with_parts")
 
-        # Create a user and log them in (this will change the client's session)
-        _ = create_and_login_user(client, "delete_with_parts")
+        # Create a user and log them in
+        _, user_token = create_and_login_user(client, "delete_with_parts")
+        user_headers = {"Authorization": f"Bearer {user_token}"}
 
         # Create a car for the user
-        car_id = create_car_for_user_cookie_auth(client)
+        car_id = create_car_for_user_cookie_auth(client, user_token)
 
         # Create a build list for the car
-        build_list_id = create_build_list_for_car_cookie_auth(client, car_id)
+        build_list_id = create_build_list_for_car_cookie_auth(client, user_token, car_id)
 
         # Get a category ID that has parts
         category_id = get_default_category_id(db_session)
@@ -371,14 +387,15 @@ class TestCategories:
             "build_list_id": build_list_id,
             "category_id": category_id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=user_headers)
         assert response.status_code == 200
 
         # Re-login as admin user for the delete operation
-        _ = create_and_login_admin_user(client, db_session, "delete_with_parts_admin")
+        _, admin_token2 = create_and_login_admin_user(client, db_session, "delete_with_parts_admin")
+        admin_headers = {"Authorization": f"Bearer {admin_token2}"}
 
         # Try to delete the category
-        response = client.delete(f"{settings.API_STR}/categories/{category_id}")
+        response = client.delete(f"{settings.API_STR}/categories/{category_id}", headers=admin_headers)
         assert response.status_code == 409  # Conflict - category has associated parts
         response_data = response.json()
         # ResponsePatterns.raise_conflict uses "detail" key for HTTPException

--- a/backend/tests/api/endpoints/test_categories_admin.py
+++ b/backend/tests/api/endpoints/test_categories_admin.py
@@ -12,8 +12,8 @@ from app.core.config import settings
 # Helper function to create and login an admin user
 def create_and_login_admin_user(
     client: TestClient, db_session: Session, username_suffix: str = "admin"
-) -> dict[str, Any]:
-    """Create an admin user and log them in."""
+) -> tuple[dict[str, Any], str]:
+    """Create an admin user and log them in. Returns (user_dict, token)."""
     username = f"admin_test_{username_suffix}"
     email = f"admin_test_{username_suffix}@example.com"
     password = "testpassword"
@@ -32,19 +32,20 @@ def create_and_login_admin_user(
     db_session.commit()
     db_session.refresh(admin_user)
 
-    # Log in to set cookie on the client
+    # Log in and get token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert token_response.status_code == 200, f"Failed to login admin user: {token_response.text}"
+    token = token_response.json()["access_token"]
 
-    return admin_user.__dict__
+    return admin_user.__dict__, token
 
 
 # Helper function to create and login a regular user
 def create_and_login_regular_user(
     client: TestClient, db_session: Session, username_suffix: str = "regular"
-) -> dict[str, Any]:
-    """Create a regular user and log them in."""
+) -> tuple[dict[str, Any], str]:
+    """Create a regular user and log them in. Returns (user_dict, token)."""
     username = f"regular_test_{username_suffix}"
     email = f"regular_test_{username_suffix}@example.com"
     password = "testpassword"
@@ -63,12 +64,13 @@ def create_and_login_regular_user(
     db_session.commit()
     db_session.refresh(regular_user)
 
-    # Log in to set cookie on the client
+    # Log in and get token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert token_response.status_code == 200, f"Failed to login regular user: {token_response.text}"
+    token = token_response.json()["access_token"]
 
-    return regular_user.__dict__
+    return regular_user.__dict__, token
 
 
 class TestCategoriesAdminAuthentication:
@@ -86,12 +88,16 @@ class TestCategoriesAdminAuthentication:
 
         response = client.post(f"{settings.API_STR}/categories/", json=category_data)
         assert response.status_code == 401, "Should require authentication"
-        assert "Could not validate credentials" in response.text
+        # Check for authentication error (message format may vary)
+        response_data = response.json()
+        response_text = response_data.get("message", "").lower()
+        assert "not authenticated" in response_text or "unauthorized" in response_text or "credentials" in response_text
 
     def test_create_category_with_regular_user(self, client: TestClient, db_session: Session) -> None:
         """Test that regular users cannot create categories."""
         # Create and login regular user
-        _ = create_and_login_regular_user(client, db_session, "create_cat")
+        _, token = create_and_login_regular_user(client, db_session, "create_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         category_data = {
             "name": "test_category",
@@ -101,14 +107,15 @@ class TestCategoriesAdminAuthentication:
             "is_active": True,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 403, "Regular users should not be able to create categories"
         assert "Admin access required" in response.text
 
     def test_create_category_with_admin_user(self, client: TestClient, db_session: Session) -> None:
         """Test that admin users can create categories."""
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "create_cat")
+        _, token = create_and_login_admin_user(client, db_session, "create_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         category_data = {
             "name": "test_category_admin",
@@ -118,7 +125,7 @@ class TestCategoriesAdminAuthentication:
             "is_active": True,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 200, f"Admin should be able to create categories: {response.text}"
 
         created_category = response.json()
@@ -149,6 +156,8 @@ class TestCategoriesAdminAuthentication:
         login_data = {"username": username, "password": password}
         token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert token_response.status_code == 200
+        token = token_response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         category_data = {
             "name": "test_category_superuser",
@@ -158,7 +167,7 @@ class TestCategoriesAdminAuthentication:
             "is_active": True,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data, headers=headers)
         assert response.status_code == 200, f"Superuser should be able to create categories: {response.text}"
 
         created_category = response.json()
@@ -201,14 +210,15 @@ class TestCategoriesAdminAuthentication:
         db_session.refresh(category)
 
         # Create and login regular user
-        _ = create_and_login_regular_user(client, db_session, "update_cat")
+        _, token = create_and_login_regular_user(client, db_session, "update_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         update_data = {
             "display_name": "Updated Category Name",
             "description": "Updated description",
         }
 
-        response = client.put(f"{settings.API_STR}/categories/{category.id}", json=update_data)
+        response = client.put(f"{settings.API_STR}/categories/{category.id}", json=update_data, headers=headers)
         assert response.status_code == 403, "Regular users should not be able to update categories"
         assert "Admin access required" in response.text
 
@@ -227,7 +237,8 @@ class TestCategoriesAdminAuthentication:
         db_session.refresh(category)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "update_cat")
+        _, token = create_and_login_admin_user(client, db_session, "update_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         update_data = {
             "display_name": "Updated Category Name by Admin",
@@ -235,7 +246,7 @@ class TestCategoriesAdminAuthentication:
             "sort_order": 5,
         }
 
-        response = client.put(f"{settings.API_STR}/categories/{category.id}", json=update_data)
+        response = client.put(f"{settings.API_STR}/categories/{category.id}", json=update_data, headers=headers)
         assert response.status_code == 200, f"Admin should be able to update categories: {response.text}"
 
         updated_category = response.json()
@@ -275,9 +286,10 @@ class TestCategoriesAdminAuthentication:
         db_session.refresh(category)
 
         # Create and login regular user
-        _ = create_and_login_regular_user(client, db_session, "delete_cat")
+        _, token = create_and_login_regular_user(client, db_session, "delete_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
-        response = client.delete(f"{settings.API_STR}/categories/{category.id}")
+        response = client.delete(f"{settings.API_STR}/categories/{category.id}", headers=headers)
         assert response.status_code == 403, "Regular users should not be able to delete categories"
         assert "Admin access required" in response.text
 
@@ -296,13 +308,14 @@ class TestCategoriesAdminAuthentication:
         db_session.refresh(category)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_cat")
+        _, token = create_and_login_admin_user(client, db_session, "delete_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
-        response = client.delete(f"{settings.API_STR}/categories/{category.id}")
+        response = client.delete(f"{settings.API_STR}/categories/{category.id}", headers=headers)
         assert response.status_code == 200, f"Admin should be able to delete categories: {response.text}"
 
         # Verify the category was deleted
-        get_response = client.get(f"{settings.API_STR}/categories/{category.id}")
+        get_response = client.get(f"{settings.API_STR}/categories/{category.id}", headers=headers)
         assert get_response.status_code == 404, "Category should be deleted"
 
     def test_delete_category_with_parts_fails(self, client: TestClient, db_session: Session) -> None:
@@ -346,9 +359,10 @@ class TestCategoriesAdminAuthentication:
         db_session.commit()
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_cat_parts")
+        _, token = create_and_login_admin_user(client, db_session, "delete_cat_parts")
+        headers = {"Authorization": f"Bearer {token}"}
 
-        response = client.delete(f"{settings.API_STR}/categories/{category.id}")
+        response = client.delete(f"{settings.API_STR}/categories/{category.id}", headers=headers)
         assert response.status_code == 409, "Should return 409 Conflict when deleting category with parts"
         assert "parts" in response.text.lower() and "category" in response.text.lower()
 
@@ -390,7 +404,8 @@ class TestCategoriesAdminAuthentication:
     def test_duplicate_category_name_fails(self, client: TestClient, db_session: Session) -> None:
         """Test that creating a category with duplicate name fails."""
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "duplicate_cat")
+        _, token = create_and_login_admin_user(client, db_session, "duplicate_cat")
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Create first category
         category_data_1 = {
@@ -401,7 +416,7 @@ class TestCategoriesAdminAuthentication:
             "is_active": True,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data_1)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data_1, headers=headers)
         assert response.status_code == 200, "First category should be created"
 
         # Try to create second category with same name
@@ -413,6 +428,6 @@ class TestCategoriesAdminAuthentication:
             "is_active": True,
         }
 
-        response = client.post(f"{settings.API_STR}/categories/", json=category_data_2)
+        response = client.post(f"{settings.API_STR}/categories/", json=category_data_2, headers=headers)
         assert response.status_code == 409, "Should return 409 Conflict for duplicate category names"
         assert "already exists" in response.text

--- a/backend/tests/api/endpoints/test_global_parts.py
+++ b/backend/tests/api/endpoints/test_global_parts.py
@@ -15,15 +15,26 @@ def get_unique_name(base_name: str) -> str:
     return f"{base_name}_{worker_id}_{pid}"
 
 
+def get_auth_token_and_headers(client: TestClient, username: str, password: str = "testpassword") -> dict[str, str]:
+    """Login and return Authorization headers with Bearer token."""
+    login_data = {"username": username, "password": password}
+    response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
+    assert response.status_code == 200
+    token = response.json()["access_token"]
+    return {"Authorization": f"Bearer {token}"}
+
+
 class TestGlobalParts:
     """Test cases for global parts endpoints."""
 
     def test_create_global_part_success(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test successful creation of a global part."""
-        # Login as test user
+        # Login as test user and get token
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Create global part
         part_data = {
@@ -33,7 +44,7 @@ class TestGlobalParts:
             "category_id": test_category.id,
             "image_url": "https://example.com/image.jpg",
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -63,6 +74,8 @@ class TestGlobalParts:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -70,11 +83,11 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
 
         # Get the list
-        response = client.get(f"{settings.API_STR}/global-parts/")
+        response = client.get(f"{settings.API_STR}/global-parts/", headers=headers)
         assert response.status_code == 200
 
         data: list[Any] = response.json()
@@ -86,9 +99,7 @@ class TestGlobalParts:
     ) -> None:
         """Test pagination for global parts list."""
         # Login and create multiple parts
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         # Create multiple parts
         for i in range(3):
@@ -98,11 +109,11 @@ class TestGlobalParts:
                 "price": 9999 + i,  # Price in cents (integer)
                 "category_id": test_category.id,
             }
-            response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+            response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
             assert response.status_code == 200
 
         # Test pagination
-        response = client.get(f"{settings.API_STR}/global-parts/?skip=0&limit=2")
+        response = client.get(f"{settings.API_STR}/global-parts/?skip=0&limit=2", headers=headers)
         assert response.status_code == 200
         data = response.json()
         assert len(data) <= 2
@@ -112,9 +123,7 @@ class TestGlobalParts:
     ) -> None:
         """Test filtering global parts by category."""
         # Login and create a part
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -122,11 +131,11 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
 
         # Filter by category
-        response = client.get(f"{settings.API_STR}/global-parts/?category_id={test_category.id}")
+        response = client.get(f"{settings.API_STR}/global-parts/?category_id={test_category.id}", headers=headers)
         assert response.status_code == 200
         data: list[Any] = response.json()
         assert isinstance(data, list)
@@ -137,9 +146,7 @@ class TestGlobalParts:
     def test_get_global_parts_with_search(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test searching global parts."""
         # Login and create a part
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         unique_name = get_unique_name("searchable_part")
         part_data = {
@@ -148,11 +155,11 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
 
         # Search by name
-        response = client.get(f"{settings.API_STR}/global-parts/?search={unique_name}")
+        response = client.get(f"{settings.API_STR}/global-parts/?search={unique_name}", headers=headers)
         assert response.status_code == 200
         data: list[Any] = response.json()
         assert isinstance(data, list)
@@ -162,9 +169,7 @@ class TestGlobalParts:
     def test_get_global_part_by_id(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test retrieving a specific global part by ID."""
         # Login and create a part
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -172,12 +177,12 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         created_part = response.json()
 
         # Get the part by ID
-        response = client.get(f"{settings.API_STR}/global-parts/{created_part['id']}")
+        response = client.get(f"{settings.API_STR}/global-parts/{created_part['id']}", headers=headers)
         assert response.status_code == 200
         data = response.json()
         assert data["id"] == created_part["id"]
@@ -191,9 +196,7 @@ class TestGlobalParts:
     def test_update_global_part_success(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test successful update of a global part."""
         # Login and create a part
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -201,7 +204,7 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         created_part = response.json()
 
@@ -211,7 +214,9 @@ class TestGlobalParts:
             "description": "Updated description",
             "price": 14999,  # Price in cents (integer)
         }
-        response = client.put(f"{settings.API_STR}/global-parts/{created_part['id']}", json=update_data)
+        response = client.put(
+            f"{settings.API_STR}/global-parts/{created_part['id']}", json=update_data, headers=headers
+        )
         assert response.status_code == 200
         data = response.json()
         assert data["name"] == update_data["name"]
@@ -223,9 +228,7 @@ class TestGlobalParts:
     ) -> None:
         """Test updating a global part without proper authorization."""
         # Create a part as test_user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -233,12 +236,9 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         created_part = response.json()
-
-        # Clear cookies to simulate different user
-        client.cookies.clear()
 
         # Try to update without authentication
         update_data = {"name": "unauthorized_update"}
@@ -248,9 +248,7 @@ class TestGlobalParts:
     def test_delete_global_part_success(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test successful deletion of a global part."""
         # Login and create a part
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -258,16 +256,16 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         created_part = response.json()
 
         # Delete the part
-        response = client.delete(f"{settings.API_STR}/global-parts/{created_part['id']}")
+        response = client.delete(f"{settings.API_STR}/global-parts/{created_part['id']}", headers=headers)
         assert response.status_code == 200
 
         # Verify it's deleted
-        response = client.get(f"{settings.API_STR}/global-parts/{created_part['id']}")
+        response = client.get(f"{settings.API_STR}/global-parts/{created_part['id']}", headers=headers)
         assert response.status_code == 404
 
     def test_delete_global_part_unauthorized(
@@ -275,9 +273,7 @@ class TestGlobalParts:
     ) -> None:
         """Test deleting a global part without proper authorization."""
         # Create a part as test_user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -285,12 +281,9 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         created_part = response.json()
-
-        # Clear cookies to simulate different user
-        client.cookies.clear()
 
         # Try to delete without authentication
         response = client.delete(f"{settings.API_STR}/global-parts/{created_part['id']}")
@@ -299,9 +292,7 @@ class TestGlobalParts:
     def test_get_global_parts_with_votes(self, client: TestClient, test_user: User, test_category: Category) -> None:
         """Test retrieving global parts with vote data."""
         # Login and create a part
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         part_data = {
             "name": get_unique_name("test_part"),
@@ -309,11 +300,11 @@ class TestGlobalParts:
             "price": 9999,
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
 
         # Get parts with votes
-        response = client.get(f"{settings.API_STR}/global-parts/with-votes")
+        response = client.get(f"{settings.API_STR}/global-parts/with-votes", headers=headers)
         assert response.status_code == 200
         result: dict[str, Any] = response.json()
         assert isinstance(result, dict)
@@ -332,9 +323,7 @@ class TestGlobalParts:
     ) -> None:
         """Test that creating a global part with an invalid price fails validation."""
         # Login as test user
-        login_data = {"username": test_user.username, "password": "testpassword"}
-        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
-        assert response.status_code == 200
+        headers = get_auth_token_and_headers(client, test_user.username)
 
         # Test with price too large for PostgreSQL integer
         part_data = {
@@ -343,7 +332,7 @@ class TestGlobalParts:
             "price": 2147483648,  # One more than max PostgreSQL integer
             "category_id": test_category.id,
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 422
         error_detail = response.json()["details"][0]
         assert error_detail["type"] == "less_than_equal"
@@ -351,7 +340,7 @@ class TestGlobalParts:
 
         # Test with negative price
         part_data["price"] = -1
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 422
         error_detail = response.json()["details"][0]
         assert error_detail["type"] == "greater_than_equal"
@@ -359,7 +348,7 @@ class TestGlobalParts:
 
         # Test with extremely large price
         part_data["price"] = 999999999999999999
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 422
         error_detail = response.json()["details"][0]
         assert error_detail["type"] == "less_than_equal"

--- a/backend/tests/api/endpoints/test_reports.py
+++ b/backend/tests/api/endpoints/test_reports.py
@@ -45,6 +45,8 @@ class TestUnifiedReports:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -53,7 +55,7 @@ class TestUnifiedReports:
             "year": 2022,
             "trim": "Sport",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -61,6 +63,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create a report
         report_data = {
@@ -70,6 +74,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/car/{car['id']}",
             json=report_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -109,13 +114,17 @@ class TestUnifiedReports:
         login_data = {"username": build_list_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        build_list_owner_token = response.json()["access_token"]
+        build_list_owner_headers = {"Authorization": f"Bearer {build_list_owner_token}"}
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("Test Build List"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(
+            f"{settings.API_STR}/build-lists/", json=build_list_data, headers=build_list_owner_headers
+        )
         assert response.status_code == 200
         build_list = response.json()
 
@@ -123,6 +132,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create a report
         report_data = {
@@ -132,6 +143,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/build_list/{build_list['id']}",
             json=report_data,
+            headers=headers,
         )
         assert response.status_code == 200
 
@@ -179,6 +191,8 @@ class TestUnifiedReports:
         login_data = {"username": part_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        part_owner_token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {part_owner_token}"}
 
         # Create a global part
         part_data = {
@@ -187,7 +201,7 @@ class TestUnifiedReports:
             "category_id": category.id,
             "price": 9999,  # price in cents (99.99)
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=headers)
         assert response.status_code == 200
         part = response.json()
 
@@ -195,6 +209,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create a report
         report_data = {
@@ -204,6 +220,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/global_part/{part['id']}",
             json=report_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
@@ -231,13 +248,15 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to report non-existent entity
         report_data = {
             "reason": "inappropriate_content",
             "description": "This entity contains inappropriate content",
         }
-        response = client.post(f"{settings.API_STR}/reports/car/99999", json=report_data)
+        response = client.post(f"{settings.API_STR}/reports/car/99999", json=report_data, headers=headers)
         assert response.status_code == 404
 
     def test_create_report_own_entity(self, client: TestClient, test_user: User, db_session: Session) -> None:
@@ -246,6 +265,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Create a car owned by the test user
         car_data = {
@@ -254,7 +275,7 @@ class TestUnifiedReports:
             "year": 2021,
             "trim": "SE",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -263,7 +284,7 @@ class TestUnifiedReports:
             "reason": "inappropriate_content",
             "description": "This car contains inappropriate content",
         }
-        response = client.post(f"{settings.API_STR}/reports/car/{car['id']}", json=report_data)
+        response = client.post(f"{settings.API_STR}/reports/car/{car['id']}", json=report_data, headers=headers)
         assert response.status_code == 400
         assert "cannot report your own" in response.json()["message"]
 
@@ -290,6 +311,8 @@ class TestUnifiedReports:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -298,7 +321,7 @@ class TestUnifiedReports:
             "year": 2023,
             "trim": "GT",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -306,6 +329,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create first report
         report_data = {
@@ -315,6 +340,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/car/{car['id']}",
             json=report_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
@@ -326,6 +352,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/car/{car['id']}",
             json=report_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 400
         assert "already reported" in response.json()["message"]
@@ -336,9 +363,11 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to list reports
-        response = client.get(f"{settings.API_STR}/reports/admin/list")
+        response = client.get(f"{settings.API_STR}/reports/admin/list", headers=headers)
         assert response.status_code == 403
 
     def test_list_reports_success(self, client: TestClient, test_admin_user: User, db_session: Session) -> None:
@@ -347,9 +376,11 @@ class TestUnifiedReports:
         login_data = {"username": test_admin_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # List reports
-        response = client.get(f"{settings.API_STR}/reports/admin/list")
+        response = client.get(f"{settings.API_STR}/reports/admin/list", headers=headers)
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
@@ -359,9 +390,11 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Get my reports
-        response = client.get(f"{settings.API_STR}/reports/my-reports")
+        response = client.get(f"{settings.API_STR}/reports/my-reports", headers=headers)
         assert response.status_code == 200
         assert isinstance(response.json(), list)
 
@@ -388,6 +421,8 @@ class TestUnifiedReports:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -396,7 +431,7 @@ class TestUnifiedReports:
             "year": 2022,
             "trim": "SS",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -404,6 +439,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create a report
         report_data = {
@@ -413,12 +450,13 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/car/{car['id']}",
             json=report_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
         report = response.json()
 
         # Get the report by ID
-        response = client.get(f"{settings.API_STR}/reports/{report['id']}")
+        response = client.get(f"{settings.API_STR}/reports/{report['id']}", headers=test_user_headers)
         assert response.status_code == 200
         retrieved_report = response.json()
         assert retrieved_report["id"] == report["id"]
@@ -430,9 +468,11 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to get non-existent report
-        response = client.get(f"{settings.API_STR}/reports/99999")
+        response = client.get(f"{settings.API_STR}/reports/99999", headers=headers)
         assert response.status_code == 404
 
     def test_update_report_status_admin_only(self, client: TestClient, test_user: User) -> None:
@@ -441,10 +481,12 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to update report status
         update_data = {"status": "resolved", "admin_notes": "Issue resolved"}
-        response = client.put(f"{settings.API_STR}/reports/1", json=update_data)
+        response = client.put(f"{settings.API_STR}/reports/1", json=update_data, headers=headers)
         assert response.status_code == 403
 
     def test_update_report_status_success(self, client: TestClient, test_admin_user: User, db_session: Session) -> None:
@@ -470,6 +512,8 @@ class TestUnifiedReports:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -478,7 +522,7 @@ class TestUnifiedReports:
             "year": 2023,
             "trim": "Premium",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -500,6 +544,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create a report
         report_data = {
@@ -509,6 +555,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/car/{car['id']}",
             json=report_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
         report = response.json()
@@ -517,9 +564,11 @@ class TestUnifiedReports:
         login_data = {"username": test_admin_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        admin_token = response.json()["access_token"]
+        admin_headers = {"Authorization": f"Bearer {admin_token}"}
 
         update_data = {"status": "resolved", "admin_notes": "Issue resolved"}
-        response = client.put(f"{settings.API_STR}/reports/{report['id']}", json=update_data)
+        response = client.put(f"{settings.API_STR}/reports/{report['id']}", json=update_data, headers=admin_headers)
         assert response.status_code == 200
         updated_report = response.json()
         assert updated_report["status"] == "resolved"
@@ -531,9 +580,11 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to delete report
-        response = client.delete(f"{settings.API_STR}/reports/1")
+        response = client.delete(f"{settings.API_STR}/reports/1", headers=headers)
         assert response.status_code == 403
 
     def test_delete_report_success(self, client: TestClient, test_admin_user: User, db_session: Session) -> None:
@@ -559,6 +610,8 @@ class TestUnifiedReports:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -567,7 +620,7 @@ class TestUnifiedReports:
             "year": 2022,
             "trim": "AMG",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -589,6 +642,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Create a report
         report_data = {
@@ -598,6 +653,7 @@ class TestUnifiedReports:
         response = client.post(
             f"{settings.API_STR}/reports/car/{car['id']}",
             json=report_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
         report = response.json()
@@ -606,8 +662,10 @@ class TestUnifiedReports:
         login_data = {"username": test_admin_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        admin_token = response.json()["access_token"]
+        admin_headers = {"Authorization": f"Bearer {admin_token}"}
 
-        response = client.delete(f"{settings.API_STR}/reports/{report['id']}")
+        response = client.delete(f"{settings.API_STR}/reports/{report['id']}", headers=admin_headers)
         assert response.status_code == 200
         assert response.json()["message"] == "Report deleted successfully"
 
@@ -617,13 +675,15 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to report with invalid entity type
         report_data = {
             "reason": "inappropriate_content",
             "description": "This entity contains inappropriate content",
         }
-        response = client.post(f"{settings.API_STR}/reports/invalid_type/1", json=report_data)
+        response = client.post(f"{settings.API_STR}/reports/invalid_type/1", json=report_data, headers=headers)
         assert response.status_code == 422  # Validation error
 
     def test_report_invalid_reason(self, client: TestClient, test_user: User, db_session: Session) -> None:
@@ -632,6 +692,8 @@ class TestUnifiedReports:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Create a car
         car_data = {
@@ -640,7 +702,7 @@ class TestUnifiedReports:
             "year": 2023,
             "trim": "Performance",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -649,5 +711,5 @@ class TestUnifiedReports:
             "reason": "invalid_reason",
             "description": "This car has an invalid reason",
         }
-        response = client.post(f"{settings.API_STR}/reports/car/{car['id']}", json=report_data)
+        response = client.post(f"{settings.API_STR}/reports/car/{car['id']}", json=report_data, headers=headers)
         assert response.status_code == 422  # Validation error

--- a/backend/tests/api/endpoints/test_subscriptions.py
+++ b/backend/tests/api/endpoints/test_subscriptions.py
@@ -23,9 +23,11 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Get subscription status
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -45,13 +47,15 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Upgrade to premium
         upgrade_data = {
             "tier": "premium",
             "payment_method": "mock_payment",
         }
-        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data)
+        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data, headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -74,13 +78,15 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to upgrade to invalid tier
         upgrade_data = {
             "tier": "invalid_tier",
             "payment_method": "mock_payment",
         }
-        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data)
+        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data, headers=headers)
         assert response.status_code == 400
 
     def test_upgrade_subscription_already_premium(self, client: TestClient, test_user: User) -> None:
@@ -89,17 +95,19 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # First upgrade to premium
         upgrade_data = {
             "tier": "premium",
             "payment_method": "mock_payment",
         }
-        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data)
+        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data, headers=headers)
         assert response.status_code == 200
 
         # Try to upgrade again
-        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data)
+        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data, headers=headers)
         assert response.status_code == 409  # 409 Conflict is correct for already having premium
 
     def test_cancel_subscription_success(self, client: TestClient, test_user: Any) -> None:
@@ -108,17 +116,19 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # First upgrade to premium
         upgrade_data = {
             "tier": "premium",
             "payment_method": "mock_payment",
         }
-        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data)
+        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data, headers=headers)
         assert response.status_code == 200
 
         # Cancel subscription
-        response = client.post(f"{settings.API_STR}/subscriptions/cancel")
+        response = client.post(f"{settings.API_STR}/subscriptions/cancel", headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -137,9 +147,11 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to cancel without having premium
-        response = client.post(f"{settings.API_STR}/subscriptions/cancel")
+        response = client.post(f"{settings.API_STR}/subscriptions/cancel", headers=headers)
         assert response.status_code == 400
 
     def test_subscription_limits_and_usage(self, client: TestClient, test_user: User) -> None:
@@ -148,9 +160,11 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Get subscription status
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
 
         data = response.json()
@@ -177,9 +191,11 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Check initial status (should be free)
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
         initial_data = response.json()
         assert initial_data["tier"] == "free"
@@ -189,22 +205,22 @@ class TestSubscriptions:
             "tier": "premium",
             "payment_method": "mock_payment",
         }
-        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data)
+        response = client.post(f"{settings.API_STR}/subscriptions/upgrade", json=upgrade_data, headers=headers)
         assert response.status_code == 200
 
         # Check premium status
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
         premium_data = response.json()
         assert premium_data["tier"] == "premium"
         assert premium_data["status"] == "active"
 
         # Cancel subscription
-        response = client.post(f"{settings.API_STR}/subscriptions/cancel")
+        response = client.post(f"{settings.API_STR}/subscriptions/cancel", headers=headers)
         assert response.status_code == 200
 
         # Check canceled status
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
         canceled_data = response.json()
         assert canceled_data["tier"] == "premium"
@@ -216,9 +232,11 @@ class TestSubscriptions:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Get initial subscription status
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
         initial_data = response.json()
         initial_usage = initial_data["usage"]["build_lists"]
@@ -229,7 +247,7 @@ class TestSubscriptions:
             "model": "Camry",
             "year": 2020,
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -239,11 +257,11 @@ class TestSubscriptions:
             "description": "Test build list",
             "car_id": car["id"],
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data, headers=headers)
         assert response.status_code == 200
 
         # Check that usage increased
-        response = client.get(f"{settings.API_STR}/subscriptions/status")
+        response = client.get(f"{settings.API_STR}/subscriptions/status", headers=headers)
         assert response.status_code == 200
         updated_data = response.json()
         updated_usage = updated_data["usage"]["build_lists"]

--- a/backend/tests/api/endpoints/test_users.py
+++ b/backend/tests/api/endpoints/test_users.py
@@ -7,10 +7,11 @@ from sqlalchemy.orm import Session
 from app.core.config import settings
 
 
-# Helper function to create a user and log them in (sets cookie on client)
+# Helper function to create a user and log them in (returns user data and token)
 def create_and_login_user(
     client: TestClient, username_suffix: str, password_override: Optional[str] = None
-) -> Dict[str, Any]:
+) -> tuple[Dict[str, Any], str]:
+    """Create a user, log them in, and return (user_data, token)."""
     username = f"user_test_{username_suffix}"
     email = f"user_test_{username_suffix}@example.com"
     password = password_override or "testpassword"
@@ -35,7 +36,7 @@ def create_and_login_user(
     else:
         response.raise_for_status()  # Raise for other unexpected errors
 
-    # Log in to set cookie on the client
+    # Log in to get Bearer token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     if token_response.status_code != 200:
@@ -43,9 +44,12 @@ def create_and_login_user(
             f"Failed to log in user {username}. Status: {token_response.status_code}, Detail: {token_response.text}"
         )
 
+    token = token_response.json()["access_token"]
+    headers = {"Authorization": f"Bearer {token}"}
+
     # If user was not created in this call (because they already existed), fetch their data now
     if not created_user_data or user_id == -1:
-        me_response = client.get(f"{settings.API_STR}/users/me")  # Uses cookie
+        me_response = client.get(f"{settings.API_STR}/users/me", headers=headers)
         if me_response.status_code == 200:
             created_user_data = me_response.json()
             user_id = created_user_data["id"]
@@ -57,7 +61,12 @@ def create_and_login_user(
     if not created_user_data or user_id == -1:
         raise Exception(f"User ID or data for {username} could not be determined.")
 
-    return created_user_data
+    return created_user_data, token
+
+
+def get_auth_headers(token: str) -> Dict[str, str]:
+    """Get Authorization headers with Bearer token."""
+    return {"Authorization": f"Bearer {token}"}
 
 
 # --- Test Cases ---
@@ -83,7 +92,7 @@ def test_create_user_success(client: TestClient, db_session: Session) -> None:
 
 
 def test_create_user_duplicate_username(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "duplicate_username_test")  # Creates and logs in first user
+    user_info, _ = create_and_login_user(client, "duplicate_username_test")  # Creates and logs in first user
 
     duplicate_user_data = {
         "username": user_info["username"],  # Same username
@@ -96,7 +105,7 @@ def test_create_user_duplicate_username(client: TestClient, db_session: Session)
 
 
 def test_create_user_duplicate_email(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "duplicate_email_test")  # Creates and logs in first user
+    user_info, _ = create_and_login_user(client, "duplicate_email_test")  # Creates and logs in first user
 
     duplicate_user_data = {
         "username": "another_username_for_email_test",
@@ -110,9 +119,10 @@ def test_create_user_duplicate_email(client: TestClient, db_session: Session) ->
 
 # --- Read User (/me) Tests ---
 def test_read_users_me_success(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "me_test")  # Logs in, client gets cookie
+    user_info, token = create_and_login_user(client, "me_test")  # Logs in, returns token
 
-    response = client.get(f"{settings.API_STR}/users/me")  # Cookie sent automatically
+    headers = get_auth_headers(token)
+    response = client.get(f"{settings.API_STR}/users/me", headers=headers)
     assert response.status_code == 200, response.text
     me_user = response.json()
     assert me_user["username"] == user_info["username"]
@@ -121,18 +131,18 @@ def test_read_users_me_success(client: TestClient, db_session: Session) -> None:
 
 
 def test_read_users_me_unauthenticated(client: TestClient, db_session: Session) -> None:
-    client.cookies.clear()  # Ensure no auth cookie
     response = client.get(f"{settings.API_STR}/users/me")
     assert response.status_code == 401  # Expect unauthorized
 
 
 # --- Read User (/{user_id}) Tests ---
 def test_read_user_by_id_success(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "read_by_id_test")
+    user_info, token = create_and_login_user(client, "read_by_id_test")
     user_id_to_read = user_info["id"]
 
     # Keep authentication as users are private
-    response = client.get(f"{settings.API_STR}/users/{user_id_to_read}")
+    headers = get_auth_headers(token)
+    response = client.get(f"{settings.API_STR}/users/{user_id_to_read}", headers=headers)
     assert response.status_code == 200, response.text
     read_user = response.json()
     assert read_user["id"] == user_id_to_read
@@ -141,15 +151,16 @@ def test_read_user_by_id_success(client: TestClient, db_session: Session) -> Non
 
 def test_read_user_by_id_not_found(client: TestClient, db_session: Session) -> None:
     # Need to be authenticated to read users
-    create_and_login_user(client, "read_not_found_test")
-    response = client.get(f"{settings.API_STR}/users/9999999")  # Non-existent ID
+    _, token = create_and_login_user(client, "read_not_found_test")
+    headers = get_auth_headers(token)
+    response = client.get(f"{settings.API_STR}/users/9999999", headers=headers)  # Non-existent ID
     assert response.status_code == 404
     assert response.json()["message"] == "User not found"
 
 
 # --- Update User Tests ---
 def test_update_own_user_success(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "update_self")
+    user_info, token = create_and_login_user(client, "update_self")
     user_id = user_info["id"]
     current_password = "testpassword"  # Default password from create_and_login_user
 
@@ -157,7 +168,8 @@ def test_update_own_user_success(client: TestClient, db_session: Session) -> Non
         "current_password": current_password,
         "email": "updated_self@example.com",
     }
-    response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload)
+    headers = get_auth_headers(token)
+    response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload, headers=headers)
     assert response.status_code == 200, response.text
     updated_user = response.json()
     assert updated_user["email"] == update_payload["email"]
@@ -169,12 +181,13 @@ def test_update_own_user_change_password_success(client: TestClient, db_session:
     initial_password = "initialPassword123"
     new_password = "newStrongPassword456"
 
-    user_info = create_and_login_user(client, username_suffix, password_override=initial_password)
+    user_info, token = create_and_login_user(client, username_suffix, password_override=initial_password)
     user_id = user_info["id"]
     username = user_info["username"]
 
     update_payload = {"current_password": initial_password, "password": new_password}
-    response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload)
+    headers = get_auth_headers(token)
+    response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload, headers=headers)
     assert response.status_code == 200, response.text
 
     client.cookies.clear()  # Clear old session
@@ -192,38 +205,41 @@ def test_update_own_user_change_password_success(client: TestClient, db_session:
 
 
 def test_update_own_user_incorrect_current_password(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "update_wrong_curr_pass")
+    user_info, token = create_and_login_user(client, "update_wrong_curr_pass")
     user_id = user_info["id"]
 
     update_payload = {
         "current_password": "thisisnotthepassword",  # Incorrect current password
         "email": "new_email_for_wrong_pass@example.com",
     }
-    response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload)
+    headers = get_auth_headers(token)
+    response = client.put(f"{settings.API_STR}/users/{user_id}", json=update_payload, headers=headers)
     assert response.status_code == status.HTTP_401_UNAUTHORIZED, response.text
     assert "incorrect current password" in response.json()["message"].lower()
 
 
 def test_update_other_user_forbidden(client: TestClient, db_session: Session) -> None:
-    user_a_info = create_and_login_user(client, "user_a_update_target")  # User A logged in
+    user_a_info, _ = create_and_login_user(client, "user_a_update_target")  # User A logged in
     user_a_id = user_a_info["id"]
-    client.cookies.clear()
 
     # User B logs in - assume default password "testpassword" from helper
-    _ = create_and_login_user(client, "user_b_updater_attacker")
+    _, token_b = create_and_login_user(client, "user_b_updater_attacker")
     user_b_password = "testpassword"
 
     update_payload = {
         "username": "MaliciousUpdate",
         "current_password": user_b_password,
     }  # Add current_password for User B
-    response = client.put(f"{settings.API_STR}/users/{user_a_id}", json=update_payload)  # User B tries to update User A
+    headers = get_auth_headers(token_b)
+    response = client.put(
+        f"{settings.API_STR}/users/{user_a_id}", json=update_payload, headers=headers
+    )  # User B tries to update User A
     assert response.status_code == status.HTTP_403_FORBIDDEN
     assert response.json()["message"] == "Not authorized to update this user"
 
 
 def test_update_user_unauthenticated(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "update_unauth_target")
+    user_info, _ = create_and_login_user(client, "update_unauth_target")
     user_id = user_info["id"]
     client.cookies.clear()  # Ensure unauthenticated
 
@@ -234,31 +250,32 @@ def test_update_user_unauthenticated(client: TestClient, db_session: Session) ->
 
 def test_update_user_not_found(client: TestClient, db_session: Session) -> None:
     # Logs in a user, assume default password "testpassword"
-    _ = create_and_login_user(client, "updater_user_notfound")
+    _, token = create_and_login_user(client, "updater_user_notfound")
     logged_in_user_password = "testpassword"
 
     update_payload = {
         "username": "NonExistent",
         "current_password": logged_in_user_password,
     }  # Add current_password
-    response = client.put(f"{settings.API_STR}/users/9999998", json=update_payload)  # Non-existent ID
+    headers = get_auth_headers(token)
+    response = client.put(f"{settings.API_STR}/users/9999998", json=update_payload, headers=headers)  # Non-existent ID
     assert response.status_code == status.HTTP_404_NOT_FOUND
     assert "User" in response.json()["message"] and "not found" in response.json()["message"]
 
 
 # --- Delete User Tests ---
 def test_delete_own_user_success(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "delete_self")
+    user_info, token = create_and_login_user(client, "delete_self")
     user_id = user_info["id"]
     username = user_info["username"]
 
-    response = client.delete(f"{settings.API_STR}/users/{user_id}")
+    headers = get_auth_headers(token)
+    response = client.delete(f"{settings.API_STR}/users/{user_id}", headers=headers)
     assert response.status_code == 200, response.text
     deleted_user = response.json()
     assert deleted_user["id"] == user_id
 
     # Verify user is deleted: try to log in
-    client.cookies.clear()
     login_data = {
         "username": username,
         "password": "testpassword",
@@ -274,19 +291,19 @@ def test_delete_own_user_success(client: TestClient, db_session: Session) -> Non
 
 
 def test_delete_other_user_forbidden(client: TestClient, db_session: Session) -> None:
-    user_a_info = create_and_login_user(client, "user_a_delete_target")  # User A logged in
+    user_a_info, _ = create_and_login_user(client, "user_a_delete_target")  # User A logged in
     user_a_id = user_a_info["id"]
-    client.cookies.clear()
 
-    _ = create_and_login_user(client, "user_b_deleter_attacker")  # User B logged in
+    _, token_b = create_and_login_user(client, "user_b_deleter_attacker")  # User B logged in
 
-    response = client.delete(f"{settings.API_STR}/users/{user_a_id}")  # User B tries to delete User A
+    headers = get_auth_headers(token_b)
+    response = client.delete(f"{settings.API_STR}/users/{user_a_id}", headers=headers)  # User B tries to delete User A
     assert response.status_code == 403
     assert response.json()["message"] == "Not authorized to delete this user"
 
 
 def test_delete_user_unauthenticated(client: TestClient, db_session: Session) -> None:
-    user_info = create_and_login_user(client, "delete_unauth_target")
+    user_info, _ = create_and_login_user(client, "delete_unauth_target")
     user_id = user_info["id"]
     client.cookies.clear()  # Ensure unauthenticated
 
@@ -295,36 +312,39 @@ def test_delete_user_unauthenticated(client: TestClient, db_session: Session) ->
 
 
 def test_delete_user_not_found(client: TestClient, db_session: Session) -> None:
-    _ = create_and_login_user(client, "deleter_user_notfound")  # Logs in a user
+    _, token = create_and_login_user(client, "deleter_user_notfound")  # Logs in a user
 
-    response = client.delete(f"{settings.API_STR}/users/9999997")  # Non-existent ID
+    headers = get_auth_headers(token)
+    response = client.delete(f"{settings.API_STR}/users/9999997", headers=headers)  # Non-existent ID
     assert response.status_code == 403  # Changed from 404
     assert response.json()["message"] == "Not authorized to delete this user"  # Changed detail
 
 
 def test_update_user_conflict_username(client: TestClient, db_session: Session) -> None:
-    user_a_info = create_and_login_user(client, "conflict_username_A")
+    user_a_info, _ = create_and_login_user(client, "conflict_username_A")
     # User B is now logged in, default password is "testpassword"
-    user_b_info = create_and_login_user(client, "conflict_username_B")
+    user_b_info, token_b = create_and_login_user(client, "conflict_username_B")
 
     update_payload = {
         "current_password": "testpassword",  # User B's current password
         "username": user_a_info["username"],
     }  # Try to set B's username to A's
-    response = client.put(f"{settings.API_STR}/users/{user_b_info['id']}", json=update_payload)
+    headers = get_auth_headers(token_b)
+    response = client.put(f"{settings.API_STR}/users/{user_b_info['id']}", json=update_payload, headers=headers)
     assert response.status_code == 409  # 409 Conflict is correct for duplicates
     assert "username already registered" in response.json()["message"].lower()
 
 
 def test_update_user_conflict_email(client: TestClient, db_session: Session) -> None:
-    user_a_info = create_and_login_user(client, "conflict_email_A")
+    user_a_info, _ = create_and_login_user(client, "conflict_email_A")
     # User B is now logged in, default password is "testpassword"
-    user_b_info = create_and_login_user(client, "conflict_email_B")
+    user_b_info, token_b = create_and_login_user(client, "conflict_email_B")
 
     update_payload = {
         "current_password": "testpassword",  # User B's current password
         "email": user_a_info["email"],
     }  # Try to set B's email to A's
-    response = client.put(f"{settings.API_STR}/users/{user_b_info['id']}", json=update_payload)
+    headers = get_auth_headers(token_b)
+    response = client.put(f"{settings.API_STR}/users/{user_b_info['id']}", json=update_payload, headers=headers)
     assert response.status_code == 409  # 409 Conflict is correct for duplicates
     assert "email already registered" in response.json()["message"].lower()

--- a/backend/tests/api/endpoints/test_users_admin.py
+++ b/backend/tests/api/endpoints/test_users_admin.py
@@ -8,11 +8,16 @@ from app.api.models.user import User as DBUser
 from app.core.config import settings
 
 
+def get_auth_headers(token: str) -> dict[str, str]:
+    """Get Authorization headers with Bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
 # Helper function to create and login an admin user
 def create_and_login_admin_user(
     client: TestClient, db_session: Session, username_suffix: str = "admin"
-) -> dict[str, Any]:
-    """Create an admin user and log them in."""
+) -> tuple[dict[str, Any], str]:
+    """Create an admin user and log them in. Returns (user_dict, token)."""
     username = f"admin_test_{username_suffix}"
     email = f"admin_test_{username_suffix}@example.com"
     password = "testpassword"
@@ -31,19 +36,20 @@ def create_and_login_admin_user(
     db_session.commit()
     db_session.refresh(admin_user)
 
-    # Log in to set cookie on the client
+    # Log in to get Bearer token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert token_response.status_code == 200, f"Failed to login admin user: {token_response.text}"
+    token = token_response.json()["access_token"]
 
-    return admin_user.__dict__
+    return admin_user.__dict__, token
 
 
 # Helper function to create and login a superuser
 def create_and_login_superuser(
     client: TestClient, db_session: Session, username_suffix: str = "superuser"
-) -> dict[str, Any]:
-    """Create a superuser and log them in."""
+) -> tuple[dict[str, Any], str]:
+    """Create a superuser and log them in. Returns (user_dict, token)."""
     username = f"superuser_test_{username_suffix}"
     email = f"superuser_test_{username_suffix}@example.com"
     password = "testpassword"
@@ -62,19 +68,20 @@ def create_and_login_superuser(
     db_session.commit()
     db_session.refresh(superuser)
 
-    # Log in to set cookie on the client
+    # Log in to get Bearer token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert token_response.status_code == 200, f"Failed to login superuser: {token_response.text}"
+    token = token_response.json()["access_token"]
 
-    return superuser.__dict__
+    return superuser.__dict__, token
 
 
 # Helper function to create and login a regular user
 def create_and_login_regular_user(
     client: TestClient, db_session: Session, username_suffix: str = "regular"
-) -> dict[str, Any]:
-    """Create a regular user and log them in."""
+) -> tuple[dict[str, Any], str]:
+    """Create a regular user and log them in. Returns (user_dict, token)."""
     username = f"regular_test_{username_suffix}"
     email = f"regular_test_{username_suffix}@example.com"
     password = "testpassword"
@@ -93,12 +100,13 @@ def create_and_login_regular_user(
     db_session.commit()
     db_session.refresh(regular_user)
 
-    # Log in to set cookie on the client
+    # Log in to get Bearer token
     login_data = {"username": username, "password": password}
     token_response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert token_response.status_code == 200, f"Failed to login regular user: {token_response.text}"
+    token = token_response.json()["access_token"]
 
-    return regular_user.__dict__
+    return regular_user.__dict__, token
 
 
 class TestAdminUserManagement:
@@ -108,14 +116,20 @@ class TestAdminUserManagement:
         """Test that getting all users without authentication fails."""
         response = client.get(f"{settings.API_STR}/users/admin/users")
         assert response.status_code == 401, "Should require authentication"
-        assert "Could not validate credentials" in response.text
+        response_data = response.json()
+        assert (
+            "not authenticated" in response_data.get("message", "").lower()
+            or "unauthorized" in response_data.get("message", "").lower()
+            or "credentials" in response_data.get("message", "").lower()
+        )
 
     def test_get_all_users_with_regular_user(self, client: TestClient, db_session: Session) -> None:
         """Test that regular users cannot get all users."""
         # Create and login regular user
-        _ = create_and_login_regular_user(client, db_session, "get_users")
+        _, token = create_and_login_regular_user(client, db_session, "get_users")
 
-        response = client.get(f"{settings.API_STR}/users/admin/users")
+        headers = get_auth_headers(token)
+        response = client.get(f"{settings.API_STR}/users/admin/users", headers=headers)
         assert response.status_code == 403, "Regular users should not be able to get all users"
         assert "Admin access required" in response.text
 
@@ -144,9 +158,10 @@ class TestAdminUserManagement:
         db_session.commit()
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "get_users")
+        _, token = create_and_login_admin_user(client, db_session, "get_users")
 
-        response = client.get(f"{settings.API_STR}/users/admin/users")
+        headers = get_auth_headers(token)
+        response = client.get(f"{settings.API_STR}/users/admin/users", headers=headers)
         assert response.status_code == 200, f"Admin should be able to get all users: {response.text}"
 
         users = response.json()
@@ -160,9 +175,10 @@ class TestAdminUserManagement:
     def test_get_all_users_with_superuser(self, client: TestClient, db_session: Session) -> None:
         """Test that superusers can get all users."""
         # Create and login superuser
-        _ = create_and_login_superuser(client, db_session, "get_users")
+        _, token = create_and_login_superuser(client, db_session, "get_users")
 
-        response = client.get(f"{settings.API_STR}/users/admin/users")
+        headers = get_auth_headers(token)
+        response = client.get(f"{settings.API_STR}/users/admin/users", headers=headers)
         assert response.status_code == 200, f"Superuser should be able to get all users: {response.text}"
 
         users = response.json()
@@ -188,24 +204,25 @@ class TestAdminUserManagement:
         db_session.commit()
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "get_users_pagination")
+        _, token = create_and_login_admin_user(client, db_session, "get_users_pagination")
+        headers = get_auth_headers(token)
 
         # Test first page (limit=2, skip=0)
-        response = client.get(f"{settings.API_STR}/users/admin/users?limit=2&skip=0")
+        response = client.get(f"{settings.API_STR}/users/admin/users?limit=2&skip=0", headers=headers)
         assert response.status_code == 200, f"Admin should be able to get users: {response.text}"
 
         users_page1 = response.json()
         assert len(users_page1) == 2
 
         # Test second page (limit=2, skip=2)
-        response = client.get(f"{settings.API_STR}/users/admin/users?limit=2&skip=2")
+        response = client.get(f"{settings.API_STR}/users/admin/users?limit=2&skip=2", headers=headers)
         assert response.status_code == 200, f"Admin should be able to get users: {response.text}"
 
         users_page2 = response.json()
         assert len(users_page2) == 2
 
         # Test third page (limit=2, skip=4)
-        response = client.get(f"{settings.API_STR}/users/admin/users?limit=2&skip=4")
+        response = client.get(f"{settings.API_STR}/users/admin/users?limit=2&skip=4", headers=headers)
         assert response.status_code == 200, f"Admin should be able to get users: {response.text}"
 
         users_page3 = response.json()
@@ -266,14 +283,15 @@ class TestAdminUserManagement:
         db_session.refresh(test_user)
 
         # Create and login regular user
-        _ = create_and_login_regular_user(client, db_session, "update_user")
+        _, token = create_and_login_regular_user(client, db_session, "update_user")
 
         update_data = {
             "username": "updated_username",
             "email": "updated_email@example.com",
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data)
+        headers = get_auth_headers(token)
+        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data, headers=headers)
         assert response.status_code == 403, "Regular users should not be able to update other users"
         assert "Admin access required" in response.text
 
@@ -294,7 +312,8 @@ class TestAdminUserManagement:
         db_session.refresh(test_user)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "update_user")
+        _, token = create_and_login_admin_user(client, db_session, "update_user")
+        headers = get_auth_headers(token)
 
         update_data = {
             "username": "updated_username_by_admin",
@@ -303,7 +322,7 @@ class TestAdminUserManagement:
             "email_verified": True,
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data)
+        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data, headers=headers)
         assert response.status_code == 200, f"Admin should be able to update users: {response.text}"
 
         updated_user = response.json()
@@ -329,7 +348,8 @@ class TestAdminUserManagement:
         db_session.refresh(test_user)
 
         # Create and login superuser
-        _ = create_and_login_superuser(client, db_session, "update_user")
+        _, token = create_and_login_superuser(client, db_session, "update_user")
+        headers = get_auth_headers(token)
 
         update_data = {
             "username": "updated_username_by_superuser",
@@ -337,7 +357,7 @@ class TestAdminUserManagement:
             "is_superuser": True,
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data)
+        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data, headers=headers)
         assert response.status_code == 200, f"Superuser should be able to update users: {response.text}"
 
         updated_user = response.json()
@@ -362,13 +382,14 @@ class TestAdminUserManagement:
         db_session.refresh(test_user)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "update_password")
+        _, token = create_and_login_admin_user(client, db_session, "update_password")
 
         update_data = {
             "password": "newpassword123",
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data)
+        headers = get_auth_headers(token)
+        response = client.put(f"{settings.API_STR}/users/admin/users/{test_user.id}", json=update_data, headers=headers)
         assert response.status_code == 200, f"Admin should be able to update user password: {response.text}"
 
         # Verify password was updated by trying to login with new password
@@ -379,13 +400,16 @@ class TestAdminUserManagement:
     def test_admin_cannot_remove_own_admin_privileges(self, client: TestClient, db_session: Session) -> None:
         """Test that admin cannot remove their own admin privileges."""
         # Create and login admin user
-        admin_user = create_and_login_admin_user(client, db_session, "remove_privileges")
+        admin_user_dict, token = create_and_login_admin_user(client, db_session, "remove_privileges")
+        headers = get_auth_headers(token)
 
         update_data = {
             "is_admin": False,
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{admin_user['id']}", json=update_data)
+        response = client.put(
+            f"{settings.API_STR}/users/admin/users/{admin_user_dict['id']}", json=update_data, headers=headers
+        )
         assert response.status_code == 400, "Admin should not be able to remove their own admin privileges"
         assert "Cannot remove your own admin privileges" in response.text
 
@@ -425,9 +449,10 @@ class TestAdminUserManagement:
         db_session.refresh(test_user)
 
         # Create and login regular user
-        _ = create_and_login_regular_user(client, db_session, "delete_user")
+        _, token = create_and_login_regular_user(client, db_session, "delete_user")
 
-        response = client.delete(f"{settings.API_STR}/users/admin/users/{test_user.id}")
+        headers = get_auth_headers(token)
+        response = client.delete(f"{settings.API_STR}/users/admin/users/{test_user.id}", headers=headers)
         assert response.status_code == 403, "Regular users should not be able to delete other users"
         assert "Admin access required" in response.text
 
@@ -448,43 +473,47 @@ class TestAdminUserManagement:
         db_session.refresh(test_user)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_user")
+        _, token = create_and_login_admin_user(client, db_session, "delete_user")
 
-        response = client.delete(f"{settings.API_STR}/users/admin/users/{test_user.id}")
+        headers = get_auth_headers(token)
+        response = client.delete(f"{settings.API_STR}/users/admin/users/{test_user.id}", headers=headers)
         assert response.status_code == 200, f"Admin should be able to delete users: {response.text}"
 
         # Verify the user was deleted
-        get_response = client.get(f"{settings.API_STR}/users/{test_user.id}")
+        get_response = client.get(f"{settings.API_STR}/users/{test_user.id}", headers=headers)
         assert get_response.status_code == 404, "User should be deleted"
 
     def test_admin_cannot_delete_themselves(self, client: TestClient, db_session: Session) -> None:
         """Test that admin cannot delete themselves."""
         # Create and login admin user
-        admin_user = create_and_login_admin_user(client, db_session, "delete_self")
+        admin_user_dict, token = create_and_login_admin_user(client, db_session, "delete_self")
+        headers = get_auth_headers(token)
 
-        response = client.delete(f"{settings.API_STR}/users/admin/users/{admin_user['id']}")
+        response = client.delete(f"{settings.API_STR}/users/admin/users/{admin_user_dict['id']}", headers=headers)
         assert response.status_code == 400, "Admin should not be able to delete themselves"
         assert "Cannot delete your own account" in response.text
 
     def test_admin_update_nonexistent_user(self, client: TestClient, db_session: Session) -> None:
         """Test that updating a nonexistent user fails."""
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "update_nonexistent")
+        _, token = create_and_login_admin_user(client, db_session, "update_nonexistent")
+        headers = get_auth_headers(token)
 
         update_data = {
             "username": "updated_username",
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/99999", json=update_data)
+        response = client.put(f"{settings.API_STR}/users/admin/users/99999", json=update_data, headers=headers)
         assert response.status_code == 404, "Should return 404 for nonexistent user"
         assert "User" in response.json()["message"] and "not found" in response.json()["message"]
 
     def test_admin_delete_nonexistent_user(self, client: TestClient, db_session: Session) -> None:
         """Test that deleting a nonexistent user fails."""
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "delete_nonexistent")
+        _, token = create_and_login_admin_user(client, db_session, "delete_nonexistent")
 
-        response = client.delete(f"{settings.API_STR}/users/admin/users/99999")
+        headers = get_auth_headers(token)
+        response = client.delete(f"{settings.API_STR}/users/admin/users/99999", headers=headers)
         assert response.status_code == 404, "Should return 404 for nonexistent user"
         assert "User" in response.json()["message"] and "not found" in response.json()["message"]
 
@@ -515,14 +544,15 @@ class TestAdminUserManagement:
         db_session.refresh(user2)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "duplicate_username")
+        _, token = create_and_login_admin_user(client, db_session, "duplicate_username")
 
         # Try to update user2 with user1's username
         update_data = {
             "username": "user1",  # Duplicate username
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{user2.id}", json=update_data)
+        headers = get_auth_headers(token)
+        response = client.put(f"{settings.API_STR}/users/admin/users/{user2.id}", json=update_data, headers=headers)
         assert response.status_code == 409, "Should return 409 Conflict for duplicate username"
         assert "already exists" in response.text
 
@@ -553,13 +583,14 @@ class TestAdminUserManagement:
         db_session.refresh(user2)
 
         # Create and login admin user
-        _ = create_and_login_admin_user(client, db_session, "duplicate_email")
+        _, token = create_and_login_admin_user(client, db_session, "duplicate_email")
 
         # Try to update user2 with user1's email
         update_data = {
             "email": "user1@example.com",  # Duplicate email
         }
 
-        response = client.put(f"{settings.API_STR}/users/admin/users/{user2.id}", json=update_data)
+        headers = get_auth_headers(token)
+        response = client.put(f"{settings.API_STR}/users/admin/users/{user2.id}", json=update_data, headers=headers)
         assert response.status_code == 409, "Should return 409 Conflict for duplicate email"
         assert "already exists" in response.text

--- a/backend/tests/api/endpoints/test_votes.py
+++ b/backend/tests/api/endpoints/test_votes.py
@@ -14,6 +14,11 @@ def get_unique_name(base_name: str) -> str:
     return f"{base_name}_{worker_id}_{pid}"
 
 
+def get_auth_headers(token: str) -> dict[str, str]:
+    """Get Authorization headers with Bearer token."""
+    return {"Authorization": f"Bearer {token}"}
+
+
 class TestUnifiedVotes:
     """Test cases for unified votes endpoints."""
 
@@ -40,6 +45,8 @@ class TestUnifiedVotes:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -48,7 +55,7 @@ class TestUnifiedVotes:
             "year": 2022,
             "trim": "Sport",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -56,12 +63,15 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Upvote the car
         vote_data = {"vote_type": "upvote"}
         response = client.post(
             f"{settings.API_STR}/votes/car/{car['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
@@ -94,13 +104,17 @@ class TestUnifiedVotes:
         login_data = {"username": build_list_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        build_list_owner_token = response.json()["access_token"]
+        build_list_owner_headers = {"Authorization": f"Bearer {build_list_owner_token}"}
 
         # Create a build list
         build_list_data = {
             "name": get_unique_name("Test Build List"),
             "description": "A test build list description",
         }
-        response = client.post(f"{settings.API_STR}/build-lists/", json=build_list_data)
+        response = client.post(
+            f"{settings.API_STR}/build-lists/", json=build_list_data, headers=build_list_owner_headers
+        )
         assert response.status_code == 200
         build_list = response.json()
 
@@ -108,12 +122,15 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Downvote the build list
         vote_data = {"vote_type": "downvote"}
         response = client.post(
             f"{settings.API_STR}/votes/build_list/{build_list['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
@@ -154,6 +171,8 @@ class TestUnifiedVotes:
         login_data = {"username": part_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        part_owner_token = response.json()["access_token"]
+        part_owner_headers = {"Authorization": f"Bearer {part_owner_token}"}
 
         # Create a global part
         part_data = {
@@ -162,7 +181,7 @@ class TestUnifiedVotes:
             "category_id": category.id,
             "price": 9999,  # price in cents (99.99)
         }
-        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data)
+        response = client.post(f"{settings.API_STR}/global-parts/", json=part_data, headers=part_owner_headers)
         assert response.status_code == 200
         part = response.json()
 
@@ -170,12 +189,15 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # Upvote the part
         vote_data = {"vote_type": "upvote"}
         response = client.post(
             f"{settings.API_STR}/votes/global_part/{part['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
@@ -198,10 +220,12 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to vote on non-existent entity
         vote_data = {"vote_type": "upvote"}
-        response = client.post(f"{settings.API_STR}/votes/car/99999", json=vote_data)
+        response = client.post(f"{settings.API_STR}/votes/car/99999", json=vote_data, headers=headers)
         assert response.status_code == 404
 
     def test_update_existing_vote(self, client: TestClient, test_user: User, db_session: Session) -> None:
@@ -227,6 +251,8 @@ class TestUnifiedVotes:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -235,7 +261,7 @@ class TestUnifiedVotes:
             "year": 2023,
             "trim": "GT",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -243,12 +269,15 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         # First upvote
         vote_data = {"vote_type": "upvote"}
         response = client.post(
             f"{settings.API_STR}/votes/car/{car['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
         first_vote = response.json()
@@ -259,6 +288,7 @@ class TestUnifiedVotes:
         response = client.post(
             f"{settings.API_STR}/votes/car/{car['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
         updated_vote = response.json()
@@ -288,6 +318,8 @@ class TestUnifiedVotes:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -296,7 +328,7 @@ class TestUnifiedVotes:
             "year": 2022,
             "trim": "SS",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -304,16 +336,19 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         vote_data = {"vote_type": "upvote"}
         response = client.post(
             f"{settings.API_STR}/votes/car/{car['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
         # Remove the vote
-        response = client.delete(f"{settings.API_STR}/votes/car/{car['id']}")
+        response = client.delete(f"{settings.API_STR}/votes/car/{car['id']}", headers=test_user_headers)
         assert response.status_code == 200
         assert response.json()["message"] == "Vote removed successfully"
 
@@ -340,6 +375,8 @@ class TestUnifiedVotes:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -348,7 +385,7 @@ class TestUnifiedVotes:
             "year": 2021,
             "trim": "330i",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -356,8 +393,10 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
-        response = client.delete(f"{settings.API_STR}/votes/car/{car['id']}")
+        response = client.delete(f"{settings.API_STR}/votes/car/{car['id']}", headers=test_user_headers)
         assert response.status_code == 404
 
     def test_get_vote_summary_success(self, client: TestClient, test_user: User, db_session: Session) -> None:
@@ -383,6 +422,8 @@ class TestUnifiedVotes:
         login_data = {"username": car_owner.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        car_owner_token = response.json()["access_token"]
+        car_owner_headers = {"Authorization": f"Bearer {car_owner_token}"}
 
         # Create a car
         car_data = {
@@ -391,7 +432,7 @@ class TestUnifiedVotes:
             "year": 2023,
             "trim": "Premium",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=car_owner_headers)
         assert response.status_code == 200
         car = response.json()
 
@@ -399,16 +440,19 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        test_user_token = response.json()["access_token"]
+        test_user_headers = {"Authorization": f"Bearer {test_user_token}"}
 
         vote_data = {"vote_type": "upvote"}
         response = client.post(
             f"{settings.API_STR}/votes/car/{car['id']}",
             json=vote_data,
+            headers=test_user_headers,
         )
         assert response.status_code == 200
 
         # Get vote summary
-        response = client.get(f"{settings.API_STR}/votes/car/{car['id']}/summary")
+        response = client.get(f"{settings.API_STR}/votes/car/{car['id']}/summary", headers=test_user_headers)
         assert response.status_code == 200
         summary = response.json()
         assert summary["entity_id"] == car["id"]
@@ -421,8 +465,15 @@ class TestUnifiedVotes:
 
     def test_get_vote_summary_not_found(self, client: TestClient, test_user: User) -> None:
         """Test getting vote summary for an entity that doesn't exist."""
+        # Login as test user
+        login_data = {"username": test_user.username, "password": "testpassword"}
+        response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
+        assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
+
         # Try to get vote summary for non-existent entity
-        response = client.get(f"{settings.API_STR}/votes/car/99999/summary")
+        response = client.get(f"{settings.API_STR}/votes/car/99999/summary", headers=headers)
         assert response.status_code == 404
 
     def test_get_flagged_entities_admin_only(self, client: TestClient, test_user: User, db_session: Session) -> None:
@@ -431,9 +482,11 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to get flagged entities
-        response = client.get(f"{settings.API_STR}/votes/admin/flagged/car")
+        response = client.get(f"{settings.API_STR}/votes/admin/flagged/car", headers=headers)
         assert response.status_code == 403
 
     def test_get_flagged_entities_success(self, client: TestClient, test_admin_user: User, db_session: Session) -> None:
@@ -442,9 +495,11 @@ class TestUnifiedVotes:
         login_data = {"username": test_admin_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Get flagged entities
-        response = client.get(f"{settings.API_STR}/votes/admin/flagged/car")
+        response = client.get(f"{settings.API_STR}/votes/admin/flagged/car", headers=headers)
         assert response.status_code == 200
         # Should return empty list if no entities meet flagging criteria
         assert isinstance(response.json(), list)
@@ -455,10 +510,12 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Try to vote with invalid entity type
         vote_data = {"vote_type": "upvote"}
-        response = client.post(f"{settings.API_STR}/votes/invalid_type/1", json=vote_data)
+        response = client.post(f"{settings.API_STR}/votes/invalid_type/1", json=vote_data, headers=headers)
         assert response.status_code == 422  # Validation error
 
     def test_vote_invalid_vote_type(self, client: TestClient, test_user: User, db_session: Session) -> None:
@@ -467,6 +524,8 @@ class TestUnifiedVotes:
         login_data = {"username": test_user.username, "password": "testpassword"}
         response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
         assert response.status_code == 200
+        token = response.json()["access_token"]
+        headers = {"Authorization": f"Bearer {token}"}
 
         # Create a car
         car_data = {
@@ -475,11 +534,11 @@ class TestUnifiedVotes:
             "year": 2023,
             "trim": "Performance",
         }
-        response = client.post(f"{settings.API_STR}/cars/", json=car_data)
+        response = client.post(f"{settings.API_STR}/cars/", json=car_data, headers=headers)
         assert response.status_code == 200
         car = response.json()
 
         # Try to vote with invalid vote type
         vote_data = {"vote_type": "invalid_vote"}
-        response = client.post(f"{settings.API_STR}/votes/car/{car['id']}", json=vote_data)
+        response = client.post(f"{settings.API_STR}/votes/car/{car['id']}", json=vote_data, headers=headers)
         assert response.status_code == 422  # Validation error

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -263,14 +263,16 @@ def get_default_category_id(db_session: Session) -> int:
     return category.id
 
 
-def login_user(client: TestClient, username: str, password: str = "testpassword") -> None:
-    """Login a user and set the authentication cookie for subsequent requests."""
+def login_user(client: TestClient, username: str, password: str = "testpassword") -> str:
+    """Login a user and return the Bearer token for use in Authorization headers."""
     from app.core.config import settings
 
     login_data = {"username": username, "password": password}
     response = client.post(f"{settings.API_STR}/auth/token", data=login_data)
     assert response.status_code == 200
-    # The cookie is automatically set by the response
+    response_data = response.json()
+    assert "access_token" in response_data
+    return response_data["access_token"]
 
 
 def create_and_login_user(
@@ -315,7 +317,7 @@ def create_and_login_user(
             user.email_verified = True
             db_session.commit()
 
-    # Login
+    # Login (token is returned but not stored - tests should use it explicitly)
     login_user(client, username, password_override)
 
     return user_data_response

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,8 +1,8 @@
 // filepath: src/contexts/AuthContext.tsx
-import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import type { ReactNode } from 'react';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import apiClient from '../services/Api';
+import apiClient, { authApi, removeStoredToken } from '../services/Api';
 import type { UserRead } from '../types/Api';
 import { AuthContext } from './AuthContextDefinition';
 
@@ -29,6 +29,12 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
       console.info('User not authenticated or failed to fetch status:', error);
       setUser(null);
       setIsAuthenticated(false);
+      // Clear invalid token on 401
+      if (
+        (error as { response?: { status?: number } }).response?.status === 401
+      ) {
+        removeStoredToken();
+      }
     } finally {
       setIsLoading(false);
     }
@@ -46,9 +52,11 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({
   const logout = useCallback(async () => {
     setIsLoading(true);
     try {
-      await apiClient.post('/auth/logout');
+      await authApi.logout();
     } catch (error) {
       console.error('Logout failed:', error);
+      // Clear token even if logout API call fails
+      removeStoredToken();
     } finally {
       setUser(null);
       setIsAuthenticated(false);

--- a/frontend/src/pages/authentication/Login.tsx
+++ b/frontend/src/pages/authentication/Login.tsx
@@ -1,13 +1,12 @@
 import React, { useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
-import Input from '../../components/common/Input';
-import Button from '../../components/buttons/Button';
-import apiClient from '../../services/Api';
-import type { UserRead } from '../../types/Api';
-import { useAuth } from '../../hooks/useAuth';
-import useApiRequest from '../../hooks/UseApiRequest';
-import { FaUser, FaLock, FaEye, FaEyeSlash } from 'react-icons/fa';
+import { FaEye, FaEyeSlash, FaLock, FaUser } from 'react-icons/fa';
 import { GiRaceCar } from 'react-icons/gi';
+import { Link, useNavigate } from 'react-router-dom';
+import Button from '../../components/buttons/Button';
+import Input from '../../components/common/Input';
+import useApiRequest from '../../hooks/UseApiRequest';
+import { useAuth } from '../../hooks/useAuth';
+import { authApi } from '../../services/Api';
 
 function Login() {
   const [username, setUsername] = useState('');
@@ -17,11 +16,7 @@ function Login() {
   const { login: authLogin } = useAuth();
 
   const loginRequestFn = (payload: URLSearchParams) =>
-    apiClient.post<UserRead>('/auth/token', payload, {
-      headers: {
-        'Content-Type': 'application/x-www-form-urlencoded',
-      },
-    });
+    authApi.login(payload as unknown as { username: string; password: string });
 
   const {
     error: apiError,

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -1,4 +1,4 @@
-import axios, { type AxiosError } from 'axios';
+import axios, { type AxiosError, type AxiosResponse } from 'axios';
 import type {
   AdminUserUpdate,
   BodyLoginForAccessToken,
@@ -68,11 +68,33 @@ const apiClient = axios.create({
   headers: {
     'Content-Type': 'application/json',
   },
-  withCredentials: true,
 });
 
+// Token storage key
+const TOKEN_STORAGE_KEY = 'access_token';
+
+// Get token from storage
+export const getStoredToken = (): string | null => {
+  return localStorage.getItem(TOKEN_STORAGE_KEY);
+};
+
+// Store token in localStorage
+export const setStoredToken = (token: string): void => {
+  localStorage.setItem(TOKEN_STORAGE_KEY, token);
+};
+
+// Remove token from storage
+export const removeStoredToken = (): void => {
+  localStorage.removeItem(TOKEN_STORAGE_KEY);
+};
+
+// Request interceptor to add Bearer token to all requests
 apiClient.interceptors.request.use(
   (config) => {
+    const token = getStoredToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
     return config;
   },
   (error) => {
@@ -462,10 +484,26 @@ export const subscriptionsApi = {
 
 // Auth API
 export const authApi = {
-  login: (data: BodyLoginForAccessToken) =>
-    apiClient.post<UserRead>('/auth/token', data, {
+  login: async (
+    data: BodyLoginForAccessToken
+  ): Promise<AxiosResponse<UserRead>> => {
+    const response = await apiClient.post<{
+      access_token: string;
+      token_type: string;
+      user: UserRead;
+    }>('/auth/token', data, {
       headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
-    }),
+    });
+    // Store the token
+    if (response.data.access_token) {
+      setStoredToken(response.data.access_token);
+    }
+    // Return response with user data as the main data field
+    return {
+      ...response,
+      data: response.data.user,
+    } as AxiosResponse<UserRead>;
+  },
   verifyEmail: (data: BodyVerifyEmail) =>
     apiClient.post<Record<string, string>>('/auth/verify-email', data),
   verifyEmailConfirm: (token: string) =>
@@ -479,7 +517,13 @@ export const authApi = {
       token,
       new_password: data,
     }),
-  logout: () => apiClient.post<Record<string, string>>('/auth/logout'),
+  logout: async () => {
+    const response =
+      await apiClient.post<Record<string, string>>('/auth/logout');
+    // Remove token from storage
+    removeStoredToken();
+    return response;
+  },
 };
 
 // Search API

--- a/frontend/src/services/Api.ts
+++ b/frontend/src/services/Api.ts
@@ -106,6 +106,13 @@ apiClient.interceptors.request.use(
 
 apiClient.interceptors.response.use(
   (response) => {
+    // Check for new access token in response header (e.g., after username change)
+    const newToken = response.headers['x-new-access-token'] as
+      | string
+      | undefined;
+    if (newToken && typeof newToken === 'string') {
+      setStoredToken(newToken);
+    }
     return response;
   },
   (error: unknown) => {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adopts FastAPI-standard OAuth2 Bearer token auth and removes cookie-based JWT handling.
> 
> - Replace cookie reads with `OAuth2PasswordBearer` in `dependencies/auth.py`; `get_current_user` and optional variants now decode Bearer tokens from `Authorization` header
> - Update `POST /auth/token` to return `{ access_token, token_type: "bearer", user }` in body; remove cookie setting; `POST /auth/logout` now just acknowledges client-side token removal
> - On username change in users update flow, stop resetting cookie and expose new token via `X-New-Access-Token` header (client should re-auth)
> - Refactor tests across auth, build lists/parts, cars, categories, and global parts to acquire tokens and send `Authorization: Bearer <token>`; remove cookie assertions and adjust expectations accordingly
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c3711d2bbdde1fddfa86ececf84fd13011d4ede1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->