### PR TITLE
fix(terraform): grant tag-sync role apprunner + servicecatalog tag perms

### DIFF
--- a/terraform/management.tf
+++ b/terraform/management.tf
@@ -127,3 +127,51 @@ resource "aws_servicecatalogappregistry_attribute_group_association" "carmodpick
   application_id     = aws_servicecatalogappregistry_application.carmodpicker.id
   attribute_group_id = aws_servicecatalogappregistry_attribute_group.carmodpicker.id
 }
+
+# ---------------------------------------------------------------------------
+# Resource Groups tag-sync role — extra permissions
+#
+# AWS auto-creates a `tag-sync-role-<region>-<suffix>` role (one per account +
+# region) the first time tag-sync is enabled on a Resource Group. The role
+# propagates the AppRegistry `awsApplication` tag to resources that match the
+# Resource Group query, so they show up under myApplications.
+#
+# AWS attaches the managed policy
+# `ResourceGroupsTaggingAPITagUntagSupportedResources`, but that policy is
+# missing `apprunner:*` and `servicecatalog:*` tag actions, so tag-sync is
+# denied when trying to tag our App Runner service + autoscaling config, and
+# the AppRegistry application + attribute group. CloudTrail shows recurring
+# `AccessDenied` TagResource events from `TagSyncTaskProcessor`.
+#
+# Fix: attach an inline policy granting the missing permissions. The role also
+# services a sibling project (webbpulse-production), so the policy name is
+# project-scoped to avoid collisions if the same fix is applied there.
+#
+# The role name has an AWS-generated suffix; if tag-sync is ever disabled and
+# re-enabled the suffix will change and this data lookup will fail loudly,
+# which is the desired behavior.
+# ---------------------------------------------------------------------------
+data "aws_iam_role" "tag_sync" {
+  name = "tag-sync-role-${var.aws_region}-k73y7vmb"
+}
+
+resource "aws_iam_role_policy" "tag_sync_apprunner_servicecatalog" {
+  name = "${local.prefix}-tag-sync-extras"
+  role = data.aws_iam_role.tag_sync.name
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "apprunner:TagResource",
+          "apprunner:UntagResource",
+          "servicecatalog:TagResource",
+          "servicecatalog:UntagResource",
+        ]
+        Resource = "*"
+      },
+    ]
+  })
+}


### PR DESCRIPTION
## Summary
- The AWS-auto-created `tag-sync-role-us-west-2-k73y7vmb` role (used by Resource Groups to propagate the AppRegistry `awsApplication` tag) is failing `AccessDenied` on our App Runner service, autoscaling config, and AppRegistry application/attribute-group. Surfacing as recurring errors under **Tag Editor → Resource tagging error status**.
- Root cause: AWS-managed policy `ResourceGroupsTaggingAPITagUntagSupportedResources` covers 345 actions but omits `apprunner:*` and `servicecatalog:*` tag actions.
- Fix: data-lookup the existing tag-sync role and attach a scoped inline policy granting the missing tag/untag permissions. Role stays AWS-owned (no import); policy name is project-scoped so the sibling `webbpulse-production` workspace can apply the same fix without collision.

## Test plan
- [ ] TFC plan shows: new `data.aws_iam_role.tag_sync` lookup + new `aws_iam_role_policy.tag_sync_apprunner_servicecatalog`. No diffs elsewhere.
- [ ] TFC apply succeeds.
- [ ] After apply, `aws servicecatalog-appregistry get-application --application 05ae92z4zr2f0zzeix6f5eim4g` shows `associatedResourceCount > 0`.
- [ ] New CloudTrail `TagResource` events from principal `TagSyncTaskProcessor` no longer return `errorCode: AccessDenied` for apprunner / servicecatalog resources.
- [ ] Tag Editor → Resource tagging error status no longer lists the 4 carmodpicker resources.

🤖 Generated with [Claude Code](https://claude.com/claude-code)