### PR TITLE
fix(backend): ensure consistent retailer name lookup and domain-to-na…

### DIFF
--- a/backend/app/api/endpoints/retailers.py
+++ b/backend/app/api/endpoints/retailers.py
@@ -124,8 +124,7 @@ def _domain_to_retailer_name(domain: str) -> str:
     base = parts[0] if parts else domain
     if not base:
         return domain
-    # Title case for readability
-    return base[0].upper() + base[1:].lower()
+    return base.title()
 
 
 @router.get("/{retailer_id}", response_model=RetailerRead)

--- a/backend/app/api/services/part_listing_service.py
+++ b/backend/app/api/services/part_listing_service.py
@@ -46,7 +46,7 @@ def get_or_create_retailer(
         )
         if retailer:
             return retailer
-    retailer = db.query(DBRetailer).filter(DBRetailer.name == name.strip()).first()
+    retailer = db.query(DBRetailer).filter(DBRetailer.name.ilike(name.strip())).first()
     if retailer:
         if domain and not retailer.domain:
             retailer.domain = domain.strip().lower()


### PR DESCRIPTION
…me conversion

Make retailer name fallback lookup case-insensitive (ilike) so crawlers find existing retailers like ADRO instead of creating duplicate Adro entries. Align _domain_to_retailer_name() to use .title() matching the crawler helper.